### PR TITLE
Update base styles– colors & buttons

### DIFF
--- a/sass/abstracts/_colors.scss
+++ b/sass/abstracts/_colors.scss
@@ -2,6 +2,7 @@
 // Base colors
 $white: #fff;
 $pale-grey: #fffff9;
+$off-white: #f7f7f2;
 $marine-blue: #003b66;
 $lipstick-red: #cc0e25;
 $dark-grey: #35352f;

--- a/sass/abstracts/_colors.scss
+++ b/sass/abstracts/_colors.scss
@@ -1,20 +1,20 @@
-
 // Base colors
 $white: #fff;
-$pale-grey: #fffff9;
+$cream: #fffffa;
 $off-white: #f7f7f2;
-$marine-blue: #003b66;
-$lipstick-red: #cc0e25;
-$dark-grey: #35352f;
+$blue: #003b63;
+$red: #bd2b2e;
+$grey: #303030;
+$gray: $grey;
 
 // Secondary colors
-$warm-grey: #a18a7c;
-$grey-blue: #76a2bb;
-$neon-red: #ff122f;
-$salmon-pink: #ff7b83;
+$light-brown: #9e8b7e;
+$light-blue: #7ea1b8;
+$light-red: #ee383b;
+$light-pink: #f98386;
 
 // Main colors in use
-$color__text: $dark-grey;
+$color__text: $grey;
 $color__background-body: $white;
 
 // General page elements
@@ -25,4 +25,4 @@ $color__border-abbr: currentColor;
 
 // Used for focused screen-reader-text, should be high-contrast.
 $color__text-screen: $color__text;
-$color__background-screen: $pale-grey;
+$color__background-screen: $cream;

--- a/sass/abstracts/_mixins-fonts.scss
+++ b/sass/abstracts/_mixins-fonts.scss
@@ -17,6 +17,8 @@
 }
 
 @mixin button {
+	display: inline-block;
+	padding: spacing(0) spacing(2);
 	font-family: $font-button;
 	@include uppercase( $font__size--body, 1.67 );
 	color: $pale-grey;
@@ -28,5 +30,28 @@
 		color: $pale-grey;
 		background-color: $dark-grey;
 	}
-	// &:focus {}
+
+	&:focus {
+		outline: none;
+	}
+}
+
+@mixin button-outline {
+	display: inline-block;
+	padding: spacing(0) spacing(2);
+	font-family: $font-button;
+	@include uppercase( $font__size--body, 1.67 );
+	color: $lipstick-red;
+	background-color: transparent;
+	border: 2px solid $lipstick-red;
+	border-radius: 12px;
+
+	@include hover-state {
+		color: $pale-grey;
+		background-color: $lipstick-red;
+	}
+
+	&:focus {
+		outline: none;
+	}
 }

--- a/sass/abstracts/_mixins-fonts.scss
+++ b/sass/abstracts/_mixins-fonts.scss
@@ -18,24 +18,64 @@
 
 @mixin button {
 	display: inline-block;
-	padding: spacing(0) spacing(2);
+	padding: spacing(0);
 	font-family: $font-button;
 	font-weight: 700;
 	@include font-size( $font__size--body );
 	color: $white;
-	background-color: $blue;
+	background-color: $red;
 	border: none;
 	border-radius: 6px;
 	transition: all 0.1s ease-in-out;
 	@include light-on-dark;
 
 	@include hover-state {
-		color: $cream;
+		color: $white;
 		background-color: $grey;
 	}
 
 	&:focus {
-		outline: none;
+		outline: 2px dotted $grey;
+		outline-offset: 2px;
+	}
+
+	&:active {
+		transform: translateY(1px);
+	}
+}
+
+@mixin button-on-dark {
+	@include button;
+	color: $red;
+	background-color: $white;
+
+	@include hover-state {
+		color: $red;
+		background-color: rgba($white, 0.9);
+	}
+
+	&:focus {
+		outline: 2px dotted rgba($white, 0.9);
+	}
+}
+
+@mixin button-alt {
+	@include button;
+	background-color: $blue;
+}
+
+@mixin button-alt-on-dark {
+	@include button-alt;
+	color: $blue;
+	background-color: $white;
+
+	@include hover-state {
+		color: $blue;
+		background-color: rgba($white, 0.9);
+	}
+
+	&:focus {
+		outline: 2px dotted rgba($white, 0.9);
 	}
 }
 
@@ -43,21 +83,27 @@
 	@include button;
 	color: $red;
 	background-color: transparent;
+	padding: spacing(0) - 2;
 	border: 2px solid $red;
 
 	@include hover-state {
-		color: $cream;
-		background-color: $red;
+		color: $gray;
+		background-color: transparent;
+		border-color: $gray;
 	}
 }
 
-@mixin button-light {
-	@include button;
-	color: $blue;
-	background-color: $white;
+@mixin button-outline-on-dark {
+	@include button-outline;
+	color: $white;
+	border-color: $white;
 
 	@include hover-state {
-		color: $white;
-		background-color: $red;
+		color: rgba($white, 0.9);
+		border-color: rgba($white, 0.9);
+	}
+
+	&:focus {
+		outline: 2px dotted rgba($white, 0.9);
 	}
 }

--- a/sass/abstracts/_mixins-fonts.scss
+++ b/sass/abstracts/_mixins-fonts.scss
@@ -40,17 +40,24 @@
 }
 
 @mixin button-outline {
-	display: inline-block;
-	padding: spacing(0) spacing(2);
-	font-family: $font-button;
-	@include uppercase( $font__size--body, 1.67 );
+	@include button;
 	color: $red;
 	background-color: transparent;
 	border: 2px solid $red;
-	border-radius: 12px;
 
 	@include hover-state {
 		color: $cream;
+		background-color: $red;
+	}
+}
+
+@mixin button-light {
+	@include button;
+	color: $blue;
+	background-color: $white;
+
+	@include hover-state {
+		color: $white;
 		background-color: $red;
 	}
 }

--- a/sass/abstracts/_mixins-fonts.scss
+++ b/sass/abstracts/_mixins-fonts.scss
@@ -20,15 +20,18 @@
 	display: inline-block;
 	padding: spacing(0) spacing(2);
 	font-family: $font-button;
-	@include uppercase( $font__size--body, 1.67 );
-	color: $pale-grey;
-	background-color: $lipstick-red;
+	font-weight: 700;
+	@include font-size( $font__size--body );
+	color: $white;
+	background-color: $blue;
 	border: none;
-	border-radius: 12px;
+	border-radius: 6px;
+	transition: all 0.1s ease-in-out;
+	@include light-on-dark;
 
 	@include hover-state {
-		color: $pale-grey;
-		background-color: $dark-grey;
+		color: $cream;
+		background-color: $grey;
 	}
 
 	&:focus {
@@ -41,17 +44,13 @@
 	padding: spacing(0) spacing(2);
 	font-family: $font-button;
 	@include uppercase( $font__size--body, 1.67 );
-	color: $lipstick-red;
+	color: $red;
 	background-color: transparent;
-	border: 2px solid $lipstick-red;
+	border: 2px solid $red;
 	border-radius: 12px;
 
 	@include hover-state {
-		color: $pale-grey;
-		background-color: $lipstick-red;
-	}
-
-	&:focus {
-		outline: none;
+		color: $cream;
+		background-color: $red;
 	}
 }

--- a/sass/elements/_blocks.scss
+++ b/sass/elements/_blocks.scss
@@ -9,5 +9,9 @@
 		&.is-style-outline .wp-block-button__link {
 			@include button-outline;
 		}
+
+		&.is-style-squared .wp-block-button__link {
+			border-radius: 0;
+		}
 	}
 }

--- a/sass/elements/_blocks.scss
+++ b/sass/elements/_blocks.scss
@@ -1,6 +1,13 @@
 .entry-content {
 
-	.wp-block-button__link {
-		@include button;
+	.wp-block-button {
+
+		.wp-block-button__link {
+			@include button;
+		}
+
+		&.is-style-outline .wp-block-button__link {
+			@include button-outline;
+		}
 	}
 }

--- a/sass/layout/_content.scss
+++ b/sass/layout/_content.scss
@@ -1,5 +1,5 @@
 .site {
-	background-color: $pale-grey;
+	background-color: $cream;
 }
 
 .site-content {
@@ -35,7 +35,7 @@
 		left: calc((50vw - #{ $size__width--nav/2 }) * -1);
 		width: 100vw;
 		background-color: $white;
-		border-bottom: 1px solid rgba($grey-blue, 0.2);
+		border-bottom: 1px solid rgba($light-blue, 0.2);
 	}
 
 	@media ( max-width: $size__width--nav ) {

--- a/sass/navigation/_links.scss
+++ b/sass/navigation/_links.scss
@@ -1,11 +1,11 @@
 a {
-	color: $lipstick-red;
+	color: $red;
 
 	&:visited {
-		color: $lipstick-red;
+		color: $red;
 	}
 
 	@include hover-state {
-		color: $marine-blue;
+		color: $blue;
 	}
 }

--- a/sass/navigation/_menus.scss
+++ b/sass/navigation/_menus.scss
@@ -15,7 +15,7 @@
 			text-align: left;
 			background-color: $white;
 			padding: spacing(0) 0;
-			border: 1px solid rgba($grey-blue, 0.2);
+			border: 1px solid rgba($light-blue, 0.2);
 			border-top: none;
 
 			ul {
@@ -67,7 +67,7 @@
 
 		&:hover > a,
 		&.focus > a {
-			color: $lipstick-red;
+			color: $red;
 			background-image: url("#{$icon-underline-hover}");
 		}
 
@@ -82,7 +82,7 @@
 		padding: 25px #{ spacing(2) / 2};
 		font-family: $font-button;
 		font-weight: 700;
-		color: $marine-blue;
+		color: $blue;
 		text-decoration: none;
 
 		background-repeat: no-repeat;
@@ -117,7 +117,7 @@
 		}
 
 		&:hover > a {
-			color: $pale-grey;
+			color: $cream;
 		}
 	}
 
@@ -127,7 +127,7 @@
 	.current-menu-ancestor {
 
 		> a {
-			color: $dark-grey;
+			color: $grey;
 			background-image: url("#{$icon-underline-current}");
 		}
 

--- a/sass/navigation/_menus.scss
+++ b/sass/navigation/_menus.scss
@@ -111,6 +111,7 @@
 			margin-top: 10px;
 			margin-left: spacing(1);
 			padding: 15px spacing(1) 15px #{spacing(1) + 27};
+			background-color: $red;
 			background-image: url("#{$icon-pencil}") !important;
 			background-position: spacing(1) center !important;
 			background-size: 17px 17px;

--- a/sass/typography/_copy.scss
+++ b/sass/typography/_copy.scss
@@ -51,3 +51,8 @@ ins {
 big {
 	font-size: 125%;
 }
+
+.cta-button {
+	@include button-outline;
+	text-decoration: none;
+}

--- a/sass/typography/_headings.scss
+++ b/sass/typography/_headings.scss
@@ -25,7 +25,7 @@ h2 {
 	@include font-size( $font__size--level-2 );
 	line-height: 1.3;
 	font-weight: 700;
-	color: $marine-blue;
+	color: $blue;
 }
 
 h3 {

--- a/style.css
+++ b/style.css
@@ -335,19 +335,26 @@ big {
   display: inline-block;
   padding: 15px 30px;
   font-family: "Nunito", "Tahoma", "Verdana", sans-serif;
+  font-weight: 700;
   font-size: 18px;
   font-size: 1.8rem;
-  font-weight: 700;
-  text-transform: uppercase;
-  letter-spacing: 1.67px;
-  line-height: 1.2;
+  color: #fff;
+  background-color: #003b63;
+  border: none;
+  border-radius: 6px;
+  -webkit-transition: all 0.1s ease-in-out;
+  transition: all 0.1s ease-in-out;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   color: #bd2b2e;
   background-color: transparent;
   border: 2px solid #bd2b2e;
-  border-radius: 12px;
   text-decoration: none; }
+  .cta-button:hover, .cta-button:active, .cta-button:focus {
+    color: #fffffa;
+    background-color: #303030; }
+  .cta-button:focus {
+    outline: none; }
   .cta-button:hover, .cta-button:active, .cta-button:focus {
     color: #fffffa;
     background-color: #bd2b2e; }
@@ -447,21 +454,31 @@ table {
   display: inline-block;
   padding: 15px 30px;
   font-family: "Nunito", "Tahoma", "Verdana", sans-serif;
+  font-weight: 700;
   font-size: 18px;
   font-size: 1.8rem;
-  font-weight: 700;
-  text-transform: uppercase;
-  letter-spacing: 1.67px;
-  line-height: 1.2;
+  color: #fff;
+  background-color: #003b63;
+  border: none;
+  border-radius: 6px;
+  -webkit-transition: all 0.1s ease-in-out;
+  transition: all 0.1s ease-in-out;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   color: #bd2b2e;
   background-color: transparent;
-  border: 2px solid #bd2b2e;
-  border-radius: 12px; }
+  border: 2px solid #bd2b2e; }
+  .entry-content .wp-block-button.is-style-outline .wp-block-button__link:hover, .entry-content .wp-block-button.is-style-outline .wp-block-button__link:active, .entry-content .wp-block-button.is-style-outline .wp-block-button__link:focus {
+    color: #fffffa;
+    background-color: #303030; }
+  .entry-content .wp-block-button.is-style-outline .wp-block-button__link:focus {
+    outline: none; }
   .entry-content .wp-block-button.is-style-outline .wp-block-button__link:hover, .entry-content .wp-block-button.is-style-outline .wp-block-button__link:active, .entry-content .wp-block-button.is-style-outline .wp-block-button__link:focus {
     color: #fffffa;
     background-color: #bd2b2e; }
+
+.entry-content .wp-block-button.is-style-squared .wp-block-button__link {
+  border-radius: 0; }
 
 /*--------------------------------------------------------------
 # Forms
@@ -634,6 +651,7 @@ a {
     margin-top: 10px;
     margin-left: 20px;
     padding: 15px 20px 15px 47px;
+    background-color: #bd2b2e;
     background-image: url("/wp-content/themes/wcus-2019/assets/pencil.svg") !important;
     background-position: 20px center !important;
     background-size: 17px 17px; }

--- a/style.css
+++ b/style.css
@@ -228,7 +228,7 @@ button,
 input,
 select,
 textarea {
-  color: #35352f;
+  color: #303030;
   font-family: "Nunito Sans", "Tahoma", "Verdana", sans-serif;
   font-size: 18px;
   font-size: 1.8rem;
@@ -266,7 +266,7 @@ h2 {
   font-size: 3.2rem;
   line-height: 1.3;
   font-weight: 700;
-  color: #003b66; }
+  color: #003b63; }
 
 h3 {
   font-size: 28px;
@@ -343,16 +343,14 @@ big {
   line-height: 1.2;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
-  color: #cc0e25;
+  color: #bd2b2e;
   background-color: transparent;
-  border: 2px solid #cc0e25;
+  border: 2px solid #bd2b2e;
   border-radius: 12px;
   text-decoration: none; }
   .cta-button:hover, .cta-button:active, .cta-button:focus {
-    color: #fffff9;
-    background-color: #cc0e25; }
-  .cta-button:focus {
-    outline: none; }
+    color: #fffffa;
+    background-color: #bd2b2e; }
 
 /*--------------------------------------------------------------
 # Elements
@@ -428,21 +426,20 @@ table {
   display: inline-block;
   padding: 15px 30px;
   font-family: "Nunito", "Tahoma", "Verdana", sans-serif;
+  font-weight: 700;
   font-size: 18px;
   font-size: 1.8rem;
-  font-weight: 700;
-  text-transform: uppercase;
-  letter-spacing: 1.67px;
-  line-height: 1.2;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-  color: #fffff9;
-  background-color: #cc0e25;
+  color: #fff;
+  background-color: #003b63;
   border: none;
-  border-radius: 12px; }
+  border-radius: 6px;
+  -webkit-transition: all 0.1s ease-in-out;
+  transition: all 0.1s ease-in-out;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale; }
   .entry-content .wp-block-button .wp-block-button__link:hover, .entry-content .wp-block-button .wp-block-button__link:active, .entry-content .wp-block-button .wp-block-button__link:focus {
-    color: #fffff9;
-    background-color: #35352f; }
+    color: #fffffa;
+    background-color: #303030; }
   .entry-content .wp-block-button .wp-block-button__link:focus {
     outline: none; }
 
@@ -458,15 +455,13 @@ table {
   line-height: 1.2;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
-  color: #cc0e25;
+  color: #bd2b2e;
   background-color: transparent;
-  border: 2px solid #cc0e25;
+  border: 2px solid #bd2b2e;
   border-radius: 12px; }
   .entry-content .wp-block-button.is-style-outline .wp-block-button__link:hover, .entry-content .wp-block-button.is-style-outline .wp-block-button__link:active, .entry-content .wp-block-button.is-style-outline .wp-block-button__link:focus {
-    color: #fffff9;
-    background-color: #cc0e25; }
-  .entry-content .wp-block-button.is-style-outline .wp-block-button__link:focus {
-    outline: none; }
+    color: #fffffa;
+    background-color: #bd2b2e; }
 
 /*--------------------------------------------------------------
 # Forms
@@ -478,18 +473,17 @@ input[type="submit"] {
   display: inline-block;
   padding: 15px 30px;
   font-family: "Nunito", "Tahoma", "Verdana", sans-serif;
+  font-weight: 700;
   font-size: 18px;
   font-size: 1.8rem;
-  font-weight: 700;
-  text-transform: uppercase;
-  letter-spacing: 1.67px;
-  line-height: 1.2;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-  color: #fffff9;
-  background-color: #cc0e25;
+  color: #fff;
+  background-color: #003b63;
   border: none;
-  border-radius: 12px; }
+  border-radius: 6px;
+  -webkit-transition: all 0.1s ease-in-out;
+  transition: all 0.1s ease-in-out;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale; }
   button:hover, button:active, button:focus,
   input[type="button"]:hover,
   input[type="button"]:active,
@@ -500,8 +494,8 @@ input[type="submit"] {
   input[type="submit"]:hover,
   input[type="submit"]:active,
   input[type="submit"]:focus {
-    color: #fffff9;
-    background-color: #35352f; }
+    color: #fffffa;
+    background-color: #303030; }
   button:focus,
   input[type="button"]:focus,
   input[type="reset"]:focus,
@@ -524,7 +518,7 @@ input[type="datetime"],
 input[type="datetime-local"],
 input[type="color"],
 textarea {
-  color: #35352f;
+  color: #303030;
   border: 1px solid currentColor;
   border-radius: 6px;
   padding: 3px; }
@@ -539,11 +533,11 @@ textarea {
 ## Links
 --------------------------------------------------------------*/
 a {
-  color: #cc0e25; }
+  color: #bd2b2e; }
   a:visited {
-    color: #cc0e25; }
+    color: #bd2b2e; }
   a:hover, a:active, a:focus {
-    color: #003b66; }
+    color: #003b63; }
 
 /*--------------------------------------------------------------
 ## Menus
@@ -563,7 +557,7 @@ a {
       text-align: left;
       background-color: #fff;
       padding: 15px 0;
-      border: 1px solid rgba(118, 162, 187, 0.2);
+      border: 1px solid rgba(126, 161, 184, 0.2);
       border-top: none; }
       .page-navigation-container ul ul ul {
         left: -999em;
@@ -597,7 +591,7 @@ a {
     position: relative; }
     .page-navigation-container li:hover > a,
     .page-navigation-container li.focus > a {
-      color: #cc0e25;
+      color: #bd2b2e;
       background-image: url("/wp-content/themes/wcus-2019/assets/underline-hover.svg"); }
     .page-navigation-container li.menu-item-has-children:hover > a::after,
     .page-navigation-container li.menu-item-has-children.focus > a::after {
@@ -607,7 +601,7 @@ a {
     padding: 25px 15px;
     font-family: "Nunito", "Tahoma", "Verdana", sans-serif;
     font-weight: 700;
-    color: #003b66;
+    color: #003b63;
     text-decoration: none;
     background-repeat: no-repeat;
     background-size: 100% 3px;
@@ -626,18 +620,17 @@ a {
     display: inline-block;
     padding: 15px 30px;
     font-family: "Nunito", "Tahoma", "Verdana", sans-serif;
+    font-weight: 700;
     font-size: 18px;
     font-size: 1.8rem;
-    font-weight: 700;
-    text-transform: uppercase;
-    letter-spacing: 1.67px;
-    line-height: 1.2;
+    color: #fff;
+    background-color: #003b63;
+    border: none;
+    border-radius: 6px;
+    -webkit-transition: all 0.1s ease-in-out;
+    transition: all 0.1s ease-in-out;
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
-    color: #fffff9;
-    background-color: #cc0e25;
-    border: none;
-    border-radius: 12px;
     margin-top: 10px;
     margin-left: 20px;
     padding: 15px 20px 15px 47px;
@@ -645,17 +638,17 @@ a {
     background-position: 20px center !important;
     background-size: 17px 17px; }
     .page-navigation-container .callout > a:hover, .page-navigation-container .callout > a:active, .page-navigation-container .callout > a:focus {
-      color: #fffff9;
-      background-color: #35352f; }
+      color: #fffffa;
+      background-color: #303030; }
     .page-navigation-container .callout > a:focus {
       outline: none; }
   .page-navigation-container .callout:hover > a {
-    color: #fffff9; }
+    color: #fffffa; }
   .page-navigation-container .current_page_item > a,
   .page-navigation-container .current-menu-item > a,
   .page-navigation-container .current_page_ancestor > a,
   .page-navigation-container .current-menu-ancestor > a {
-    color: #35352f;
+    color: #303030;
     background-image: url("/wp-content/themes/wcus-2019/assets/underline-current.svg"); }
   .page-navigation-container .current_page_item.menu-item-has-children > a::after,
   .page-navigation-container .current-menu-item.menu-item-has-children > a::after,
@@ -729,12 +722,12 @@ a {
   width: 1px;
   overflow: hidden; }
   .screen-reader-text:focus {
-    background-color: #fffff9;
+    background-color: #fffffa;
     border-radius: 3px;
     -webkit-box-shadow: 0 0 2px 2px rgba(0, 0, 0, 0.6);
             box-shadow: 0 0 2px 2px rgba(0, 0, 0, 0.6);
     clip: auto !important;
-    color: #35352f;
+    color: #303030;
     display: block;
     font-size: 14px;
     font-size: 1.4rem;
@@ -812,7 +805,7 @@ a {
 # Content
 --------------------------------------------------------------*/
 .site {
-  background-color: #fffff9; }
+  background-color: #fffffa; }
 
 .site-content {
   margin: 0 auto;
@@ -843,7 +836,7 @@ a {
     left: calc((50vw - 620px) * -1);
     width: 100vw;
     background-color: #fff;
-    border-bottom: 1px solid rgba(118, 162, 187, 0.2); }
+    border-bottom: 1px solid rgba(126, 161, 184, 0.2); }
   @media (max-width: 1240px) {
     .site-header::before {
       left: 0; } }
@@ -856,14 +849,6 @@ a {
   -webkit-box-flex: 1;
       -ms-flex: 1;
           flex: 1; }
-
-.footer-widgets-block#footer-widget-2, .footer-widgets-block#footer-widget-3 {
-  background: #003b66;
-  color: #fff; }
-
-.footer-widgets-block .widget {
-  max-width: 940px;
-  margin: 0 auto; }
 
 /*--------------------------------------------------------------
 ## Posts and pages

--- a/style.css
+++ b/style.css
@@ -331,6 +331,29 @@ ins {
 big {
   font-size: 125%; }
 
+.cta-button {
+  display: inline-block;
+  padding: 15px 30px;
+  font-family: "Nunito", "Tahoma", "Verdana", sans-serif;
+  font-size: 18px;
+  font-size: 1.8rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 1.67px;
+  line-height: 1.2;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  color: #cc0e25;
+  background-color: transparent;
+  border: 2px solid #cc0e25;
+  border-radius: 12px;
+  text-decoration: none; }
+  .cta-button:hover, .cta-button:active, .cta-button:focus {
+    color: #fffff9;
+    background-color: #cc0e25; }
+  .cta-button:focus {
+    outline: none; }
+
 /*--------------------------------------------------------------
 # Elements
 --------------------------------------------------------------*/
@@ -401,7 +424,9 @@ table {
   margin: 0 0 1.5em;
   width: 100%; }
 
-.entry-content .wp-block-button__link {
+.entry-content .wp-block-button .wp-block-button__link {
+  display: inline-block;
+  padding: 15px 30px;
   font-family: "Nunito", "Tahoma", "Verdana", sans-serif;
   font-size: 18px;
   font-size: 1.8rem;
@@ -415,9 +440,33 @@ table {
   background-color: #cc0e25;
   border: none;
   border-radius: 12px; }
-  .entry-content .wp-block-button__link:hover, .entry-content .wp-block-button__link:active, .entry-content .wp-block-button__link:focus {
+  .entry-content .wp-block-button .wp-block-button__link:hover, .entry-content .wp-block-button .wp-block-button__link:active, .entry-content .wp-block-button .wp-block-button__link:focus {
     color: #fffff9;
     background-color: #35352f; }
+  .entry-content .wp-block-button .wp-block-button__link:focus {
+    outline: none; }
+
+.entry-content .wp-block-button.is-style-outline .wp-block-button__link {
+  display: inline-block;
+  padding: 15px 30px;
+  font-family: "Nunito", "Tahoma", "Verdana", sans-serif;
+  font-size: 18px;
+  font-size: 1.8rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 1.67px;
+  line-height: 1.2;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  color: #cc0e25;
+  background-color: transparent;
+  border: 2px solid #cc0e25;
+  border-radius: 12px; }
+  .entry-content .wp-block-button.is-style-outline .wp-block-button__link:hover, .entry-content .wp-block-button.is-style-outline .wp-block-button__link:active, .entry-content .wp-block-button.is-style-outline .wp-block-button__link:focus {
+    color: #fffff9;
+    background-color: #cc0e25; }
+  .entry-content .wp-block-button.is-style-outline .wp-block-button__link:focus {
+    outline: none; }
 
 /*--------------------------------------------------------------
 # Forms
@@ -426,6 +475,8 @@ button,
 input[type="button"],
 input[type="reset"],
 input[type="submit"] {
+  display: inline-block;
+  padding: 15px 30px;
   font-family: "Nunito", "Tahoma", "Verdana", sans-serif;
   font-size: 18px;
   font-size: 1.8rem;
@@ -451,6 +502,11 @@ input[type="submit"] {
   input[type="submit"]:focus {
     color: #fffff9;
     background-color: #35352f; }
+  button:focus,
+  input[type="button"]:focus,
+  input[type="reset"]:focus,
+  input[type="submit"]:focus {
+    outline: none; }
 
 input[type="text"],
 input[type="email"],
@@ -567,6 +623,8 @@ a {
     height: 1em;
     background: url("/wp-content/themes/wcus-2019/assets/arrow-down.svg") no-repeat center; }
   .page-navigation-container .callout > a {
+    display: inline-block;
+    padding: 15px 30px;
     font-family: "Nunito", "Tahoma", "Verdana", sans-serif;
     font-size: 18px;
     font-size: 1.8rem;
@@ -589,6 +647,8 @@ a {
     .page-navigation-container .callout > a:hover, .page-navigation-container .callout > a:active, .page-navigation-container .callout > a:focus {
       color: #fffff9;
       background-color: #35352f; }
+    .page-navigation-container .callout > a:focus {
+      outline: none; }
   .page-navigation-container .callout:hover > a {
     color: #fffff9; }
   .page-navigation-container .current_page_item > a,
@@ -796,6 +856,14 @@ a {
   -webkit-box-flex: 1;
       -ms-flex: 1;
           flex: 1; }
+
+.footer-widgets-block#footer-widget-2, .footer-widgets-block#footer-widget-3 {
+  background: #003b66;
+  color: #fff; }
+
+.footer-widgets-block .widget {
+  max-width: 940px;
+  margin: 0 auto; }
 
 /*--------------------------------------------------------------
 ## Posts and pages

--- a/style.css
+++ b/style.css
@@ -333,13 +333,13 @@ big {
 
 .cta-button {
   display: inline-block;
-  padding: 15px 30px;
+  padding: 15px;
   font-family: "Nunito", "Tahoma", "Verdana", sans-serif;
   font-weight: 700;
   font-size: 18px;
   font-size: 1.8rem;
   color: #fff;
-  background-color: #003b63;
+  background-color: #bd2b2e;
   border: none;
   border-radius: 6px;
   -webkit-transition: all 0.1s ease-in-out;
@@ -348,16 +348,22 @@ big {
   -moz-osx-font-smoothing: grayscale;
   color: #bd2b2e;
   background-color: transparent;
+  padding: 13px;
   border: 2px solid #bd2b2e;
   text-decoration: none; }
   .cta-button:hover, .cta-button:active, .cta-button:focus {
-    color: #fffffa;
+    color: #fff;
     background-color: #303030; }
   .cta-button:focus {
-    outline: none; }
+    outline: 2px dotted #303030;
+    outline-offset: 2px; }
+  .cta-button:active {
+    -webkit-transform: translateY(1px);
+            transform: translateY(1px); }
   .cta-button:hover, .cta-button:active, .cta-button:focus {
-    color: #fffffa;
-    background-color: #bd2b2e; }
+    color: #303030;
+    background-color: transparent;
+    border-color: #303030; }
 
 /*--------------------------------------------------------------
 # Elements
@@ -431,13 +437,13 @@ table {
 
 .entry-content .wp-block-button .wp-block-button__link {
   display: inline-block;
-  padding: 15px 30px;
+  padding: 15px;
   font-family: "Nunito", "Tahoma", "Verdana", sans-serif;
   font-weight: 700;
   font-size: 18px;
   font-size: 1.8rem;
   color: #fff;
-  background-color: #003b63;
+  background-color: #bd2b2e;
   border: none;
   border-radius: 6px;
   -webkit-transition: all 0.1s ease-in-out;
@@ -445,20 +451,24 @@ table {
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale; }
   .entry-content .wp-block-button .wp-block-button__link:hover, .entry-content .wp-block-button .wp-block-button__link:active, .entry-content .wp-block-button .wp-block-button__link:focus {
-    color: #fffffa;
+    color: #fff;
     background-color: #303030; }
   .entry-content .wp-block-button .wp-block-button__link:focus {
-    outline: none; }
+    outline: 2px dotted #303030;
+    outline-offset: 2px; }
+  .entry-content .wp-block-button .wp-block-button__link:active {
+    -webkit-transform: translateY(1px);
+            transform: translateY(1px); }
 
 .entry-content .wp-block-button.is-style-outline .wp-block-button__link {
   display: inline-block;
-  padding: 15px 30px;
+  padding: 15px;
   font-family: "Nunito", "Tahoma", "Verdana", sans-serif;
   font-weight: 700;
   font-size: 18px;
   font-size: 1.8rem;
   color: #fff;
-  background-color: #003b63;
+  background-color: #bd2b2e;
   border: none;
   border-radius: 6px;
   -webkit-transition: all 0.1s ease-in-out;
@@ -467,15 +477,21 @@ table {
   -moz-osx-font-smoothing: grayscale;
   color: #bd2b2e;
   background-color: transparent;
+  padding: 13px;
   border: 2px solid #bd2b2e; }
   .entry-content .wp-block-button.is-style-outline .wp-block-button__link:hover, .entry-content .wp-block-button.is-style-outline .wp-block-button__link:active, .entry-content .wp-block-button.is-style-outline .wp-block-button__link:focus {
-    color: #fffffa;
+    color: #fff;
     background-color: #303030; }
   .entry-content .wp-block-button.is-style-outline .wp-block-button__link:focus {
-    outline: none; }
+    outline: 2px dotted #303030;
+    outline-offset: 2px; }
+  .entry-content .wp-block-button.is-style-outline .wp-block-button__link:active {
+    -webkit-transform: translateY(1px);
+            transform: translateY(1px); }
   .entry-content .wp-block-button.is-style-outline .wp-block-button__link:hover, .entry-content .wp-block-button.is-style-outline .wp-block-button__link:active, .entry-content .wp-block-button.is-style-outline .wp-block-button__link:focus {
-    color: #fffffa;
-    background-color: #bd2b2e; }
+    color: #303030;
+    background-color: transparent;
+    border-color: #303030; }
 
 .entry-content .wp-block-button.is-style-squared .wp-block-button__link {
   border-radius: 0; }
@@ -488,13 +504,13 @@ input[type="button"],
 input[type="reset"],
 input[type="submit"] {
   display: inline-block;
-  padding: 15px 30px;
+  padding: 15px;
   font-family: "Nunito", "Tahoma", "Verdana", sans-serif;
   font-weight: 700;
   font-size: 18px;
   font-size: 1.8rem;
   color: #fff;
-  background-color: #003b63;
+  background-color: #bd2b2e;
   border: none;
   border-radius: 6px;
   -webkit-transition: all 0.1s ease-in-out;
@@ -511,13 +527,20 @@ input[type="submit"] {
   input[type="submit"]:hover,
   input[type="submit"]:active,
   input[type="submit"]:focus {
-    color: #fffffa;
+    color: #fff;
     background-color: #303030; }
   button:focus,
   input[type="button"]:focus,
   input[type="reset"]:focus,
   input[type="submit"]:focus {
-    outline: none; }
+    outline: 2px dotted #303030;
+    outline-offset: 2px; }
+  button:active,
+  input[type="button"]:active,
+  input[type="reset"]:active,
+  input[type="submit"]:active {
+    -webkit-transform: translateY(1px);
+            transform: translateY(1px); }
 
 input[type="text"],
 input[type="email"],
@@ -635,13 +658,13 @@ a {
     background: url("/wp-content/themes/wcus-2019/assets/arrow-down.svg") no-repeat center; }
   .page-navigation-container .callout > a {
     display: inline-block;
-    padding: 15px 30px;
+    padding: 15px;
     font-family: "Nunito", "Tahoma", "Verdana", sans-serif;
     font-weight: 700;
     font-size: 18px;
     font-size: 1.8rem;
     color: #fff;
-    background-color: #003b63;
+    background-color: #bd2b2e;
     border: none;
     border-radius: 6px;
     -webkit-transition: all 0.1s ease-in-out;
@@ -656,10 +679,14 @@ a {
     background-position: 20px center !important;
     background-size: 17px 17px; }
     .page-navigation-container .callout > a:hover, .page-navigation-container .callout > a:active, .page-navigation-container .callout > a:focus {
-      color: #fffffa;
+      color: #fff;
       background-color: #303030; }
     .page-navigation-container .callout > a:focus {
-      outline: none; }
+      outline: 2px dotted #303030;
+      outline-offset: 2px; }
+    .page-navigation-container .callout > a:active {
+      -webkit-transform: translateY(1px);
+              transform: translateY(1px); }
   .page-navigation-container .callout:hover > a {
     color: #fffffa; }
   .page-navigation-container .current_page_item > a,


### PR DESCRIPTION
Thanks to @kjellr's [styleguide](https://codepen.io/kjellr/full/OGPZjY) we have easier colors names, the right hex values, & some basic button styles. This PR is to update these variables & mixins now, before development gets too far (and we have to deal with rebase nightmares 😅)

Example of the new blue button, the outline button using the right red, and heading using the right blue.

<img width="970" alt="Screen Shot 2019-04-09 at 8 48 46 PM" src="https://user-images.githubusercontent.com/541093/55844017-5cb96d00-5b09-11e9-9c42-fe6c0f49f908.png">
 
The styleguide doesn't show a hover/focus state for the plain button, unless it's also meant to be the red bg like the light button?