### PR TITLE
Style Cover block

### DIFF
--- a/sass/abstracts/_mixins-fonts.scss
+++ b/sass/abstracts/_mixins-fonts.scss
@@ -25,7 +25,7 @@
 	color: $white;
 	background-color: $red;
 	border: none;
-	border-radius: 6px;
+	border-radius: $size__border-radius--small;
 	transition: all 0.1s ease-in-out;
 	@include light-on-dark;
 

--- a/sass/abstracts/_structure.scss
+++ b/sass/abstracts/_structure.scss
@@ -11,6 +11,7 @@ $size__height--wave-small: 60px;
 $size__width--sidebar: $size__width--main/4;
 
 $size__border-radius: 12px;
+$size__border-radius--small: 6px;
 
 @function spacing( $i: 1 ) {
 	@if ( $i == 0 ) {

--- a/sass/elements/blocks/_blocks.scss
+++ b/sass/elements/blocks/_blocks.scss
@@ -69,9 +69,17 @@ hr {
 	border-radius: $size__border-radius;
 
 	h2,
-	.wp-block-cover-image-text,
 	.wp-block-cover-text {
 		color: $cream;
+	}
+
+	// Used in current WP for text (before block was changed to allow child blocks).
+	.wp-block-cover-text {
+		font-family: $font-header;
+		@include font-size( $font__size--level-2 );
+		line-height: 1.3;
+		font-weight: 700;
+		@include light-on-dark;
 	}
 }
 

--- a/sass/elements/blocks/_blocks.scss
+++ b/sass/elements/blocks/_blocks.scss
@@ -64,5 +64,16 @@ hr {
 	}
 }
 
+.wp-block-cover {
+	background-color: $grey;
+	border-radius: $size__border-radius;
+
+	h2,
+	.wp-block-cover-image-text,
+	.wp-block-cover-text {
+		color: $cream;
+	}
+}
+
 @import "media-text";
 @import "latest-posts";

--- a/sass/forms/_fields.scss
+++ b/sass/forms/_fields.scss
@@ -16,7 +16,7 @@ input[type="color"],
 textarea {
 	color: $color__text;
 	border: 2px solid $color__text;
-	border-radius: 6px;
+	border-radius: $size__border-radius--small;
 	// 13 is a better padding than the spacing rhythm gives us.
 	padding: 13px spacing(1);
 

--- a/style.css
+++ b/style.css
@@ -569,6 +569,14 @@ hr {
     hr.wp-block-separator.is-style-wide::after {
       right: 0; }
 
+.wp-block-cover {
+  background-color: #303030;
+  border-radius: 12px; }
+  .wp-block-cover h2,
+  .wp-block-cover .wp-block-cover-image-text,
+  .wp-block-cover .wp-block-cover-text {
+    color: #fffffa; }
+
 .wp-block-media-text {
   margin: 20px 0;
   grid-gap: 20px;

--- a/style.css
+++ b/style.css
@@ -573,9 +573,16 @@ hr {
   background-color: #303030;
   border-radius: 12px; }
   .wp-block-cover h2,
-  .wp-block-cover .wp-block-cover-image-text,
   .wp-block-cover .wp-block-cover-text {
     color: #fffffa; }
+  .wp-block-cover .wp-block-cover-text {
+    font-family: "Nunito", "Tahoma", "Verdana", sans-serif;
+    font-size: 32px;
+    font-size: 3.2rem;
+    line-height: 1.3;
+    font-weight: 700;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale; }
 
 .wp-block-media-text {
   margin: 20px 0;


### PR DESCRIPTION
Fixes #15 – Add the styles for the cover block. This updates the overlay color, and styles the text content as a header (will only apply to current block, if we can update to the `InnerBlocks` cover block, it won't style everything like a header). We can also adjust spacing between blocks once we have more blocks coded.

![Screen Shot 2019-04-27 at 1 01 41 PM](https://user-images.githubusercontent.com/541093/56852730-c9e04700-68ec-11e9-8483-fd91d8148e69.png)
 

