### PR TITLE
Style quote blocks: pullquote, 2 styles of blockquote

### DIFF
--- a/sass/abstracts/_assets.scss
+++ b/sass/abstracts/_assets.scss
@@ -9,7 +9,7 @@ $icon-underline-current: "https://wc-us.org/wp-content/uploads/2019/04/underline
 // General icons
 $icon-pencil: "https://wc-us.org/wp-content/uploads/2019/04/pencil.svg";
 $icon-speaking: "https://wc-us.org/wp-content/uploads/2019/04/speech.svg";
-$icon-quote: "https://wc-us.org/wp-content/uploads/2019/04/quote.svg";
+$icon-quote: "https://wc-us.org/wp-content/uploads/2019/04/quotes.svg";
 $icon-text: "https://wc-us.org/wp-content/uploads/2019/04/text-bubble.svg";
 
 // Other UI assets

--- a/sass/abstracts/_assets.scss
+++ b/sass/abstracts/_assets.scss
@@ -1,16 +1,20 @@
+
+// Used in navigation
 $icon-arrow-down: "https://wc-us.org/wp-content/uploads/2019/04/arrow-down.svg";
 $icon-arrow-down-hover: "https://wc-us.org/wp-content/uploads/2019/04/arrow-down-hover.svg";
 $icon-arrow-down-current: "https://wc-us.org/wp-content/uploads/2019/04/arrow-down-current.svg";
-
-$icon-pencil: "https://wc-us.org/wp-content/uploads/2019/04/pencil.svg";
-
 $icon-underline-hover: "https://wc-us.org/wp-content/uploads/2019/04/underline-hover.svg";
 $icon-underline-current: "https://wc-us.org/wp-content/uploads/2019/04/underline-current.svg";
 
-$border-light-blue: "https://wc-us.org/wp-content/uploads/2019/04/pale-blue-dots.svg";
+// General icons
+$icon-pencil: "https://wc-us.org/wp-content/uploads/2019/04/pencil.svg";
+$icon-speaking: "https://wc-us.org/wp-content/uploads/2019/04/speech.svg";
+$icon-quote: "https://wc-us.org/wp-content/uploads/2019/04/quote.svg";
+$icon-text: "https://wc-us.org/wp-content/uploads/2019/04/text-bubble.svg";
 
+// Other UI assets
+$border-light-blue: "https://wc-us.org/wp-content/uploads/2019/04/pale-blue-dots.svg";
 $sep-dots-sparkles: "https://wc-us.org/wp-content/uploads/2019/04/Separator-Dots-Sparkles.svg";
 $sep-wide-sparkles: "https://wc-us.org/wp-content/uploads/2019/04/Separator-Wide-Sparkles.svg";
 $sep-dots: "https://wc-us.org/wp-content/uploads/2019/04/border-dot.svg";
-
 $short-wave: "https://wc-us.org/wp-content/uploads/2019/04/short-wave.svg";

--- a/sass/abstracts/_colors.scss
+++ b/sass/abstracts/_colors.scss
@@ -8,6 +8,8 @@ $grey: #303030;
 $gray: $grey;
 
 // Secondary colors
+$dark-brown: #561315;
+$mid-brown: #747466;
 $light-brown: #9e8b7e;
 $light-blue: #7ea1b8;
 $light-red: #ee383b;

--- a/sass/elements/blocks/_blockquote.scss
+++ b/sass/elements/blocks/_blockquote.scss
@@ -1,0 +1,44 @@
+.wp-block-quote {
+	margin: 0 0 spacing(1);
+
+	p {
+		margin: 0;
+
+		+ p {
+			margin-top: spacing(1);
+		}
+
+		&:last-of-type {
+			margin-bottom: spacing(1);
+		}
+	}
+
+	cite {
+		padding-left: spacing(2);
+		background: url("#{$icon-text}") top left no-repeat;
+		@include font-size($font__size--small);
+		color: $mid-brown;
+	}
+
+	&.is-style-large {
+		margin-left: spacing(3) * -1;
+		padding: 0 0 0 spacing(3);
+		background: url("#{$icon-quote}") top left no-repeat;
+
+		@media (max-width: $breakpoint-medium) {
+			margin-left: 0;
+			padding-left: 0;
+			text-indent: 60px;
+		}
+
+		cite {
+			padding-left: 0;
+			background: none;
+			@include font-size($font__size--body);
+
+			&::before {
+				content: "— ";
+			}
+		}
+	}
+}

--- a/sass/elements/blocks/_blocks.scss
+++ b/sass/elements/blocks/_blocks.scss
@@ -85,3 +85,4 @@ hr {
 
 @import "media-text";
 @import "latest-posts";
+@import "pullquote";

--- a/sass/elements/blocks/_blocks.scss
+++ b/sass/elements/blocks/_blocks.scss
@@ -1,5 +1,15 @@
 .entry-content {
 
+	> p,
+	> ul,
+	> [class*="wp-block"] {
+		margin-bottom: spacing(2);
+	}
+
+	.wp-block-spacer {
+		margin: 0 !important;
+	}
+
 	.wp-block-button {
 
 		.wp-block-button__link {
@@ -86,3 +96,4 @@ hr {
 @import "media-text";
 @import "latest-posts";
 @import "pullquote";
+@import "blockquote";

--- a/sass/elements/blocks/_pullquote.scss
+++ b/sass/elements/blocks/_pullquote.scss
@@ -1,4 +1,5 @@
-.wp-block-pullquote {
+// Double-specificity to override the other pullquote styles.
+.wp-block-pullquote.wp-block-pullquote {
 	// Override the style difference between regular/solid color
 	background: $grey url("#{$icon-speaking}") spacing(3) center no-repeat !important;
 	color: $cream;
@@ -6,10 +7,15 @@
 	border-radius: $size__border-radius;
 	text-align: left;
 	font-style: italic;
-	padding-left: spacing(9);
+	padding: spacing(3) spacing(3) spacing(3) spacing(9);
+
+	blockquote {
+		margin: 0;
+	}
 
 	p {
 		margin: 0;
+		@include font-size(3);
 
 		+ p {
 			margin-top: spacing(2);
@@ -28,8 +34,19 @@
 		}
 	}
 
+	&.is-style-solid-color {
+
+		blockquote {
+			max-width: 100%;
+
+			p {
+				@include font-size(3);
+			}
+		}
+	}
+
 	@media (max-width: $breakpoint-small) {
-		padding-left: spacing(2);
+		padding-left: spacing(3);
 		background-size: 70px 66px !important;
 		background-position: spacing(2) spacing(2) !important;
 		text-indent: 60px;

--- a/sass/elements/blocks/_pullquote.scss
+++ b/sass/elements/blocks/_pullquote.scss
@@ -1,0 +1,37 @@
+.wp-block-pullquote {
+	// Override the style difference between regular/solid color
+	background: $grey url("#{$icon-speaking}") spacing(3) center no-repeat !important;
+	color: $cream;
+	@include light-on-dark;
+	border-radius: $size__border-radius;
+	text-align: left;
+	font-style: italic;
+	padding-left: spacing(9);
+
+	p {
+		margin: 0;
+
+		+ p {
+			margin-top: spacing(2);
+		}
+
+		&:last-of-type {
+			margin-bottom: spacing(2);
+		}
+	}
+
+	cite {
+		color: rgba($cream, 0.7);
+
+		&::before {
+			content: "— ";
+		}
+	}
+
+	@media (max-width: $breakpoint-small) {
+		padding-left: spacing(2);
+		background-size: 70px 66px !important;
+		background-position: spacing(2) spacing(2) !important;
+		text-indent: 60px;
+	}
+}

--- a/style.css
+++ b/style.css
@@ -676,7 +676,7 @@ hr {
         -ms-flex-item-align: end;
             align-self: flex-end; } }
 
-.wp-block-pullquote {
+.wp-block-pullquote.wp-block-pullquote {
   background: #303030 url("https://wc-us.org/wp-content/uploads/2019/04/speech.svg") 60px center no-repeat !important;
   color: #fffffa;
   -webkit-font-smoothing: antialiased;
@@ -684,20 +684,29 @@ hr {
   border-radius: 12px;
   text-align: left;
   font-style: italic;
-  padding-left: 240px; }
-  .wp-block-pullquote p {
+  padding: 60px 60px 60px 240px; }
+  .wp-block-pullquote.wp-block-pullquote blockquote {
     margin: 0; }
-    .wp-block-pullquote p + p {
+  .wp-block-pullquote.wp-block-pullquote p {
+    margin: 0;
+    font-size: 30px;
+    font-size: 3rem; }
+    .wp-block-pullquote.wp-block-pullquote p + p {
       margin-top: 30px; }
-    .wp-block-pullquote p:last-of-type {
+    .wp-block-pullquote.wp-block-pullquote p:last-of-type {
       margin-bottom: 30px; }
-  .wp-block-pullquote cite {
+  .wp-block-pullquote.wp-block-pullquote cite {
     color: rgba(255, 255, 250, 0.7); }
-    .wp-block-pullquote cite::before {
+    .wp-block-pullquote.wp-block-pullquote cite::before {
       content: "— "; }
+  .wp-block-pullquote.wp-block-pullquote.is-style-solid-color blockquote {
+    max-width: 100%; }
+    .wp-block-pullquote.wp-block-pullquote.is-style-solid-color blockquote p {
+      font-size: 30px;
+      font-size: 3rem; }
   @media (max-width: 600px) {
-    .wp-block-pullquote {
-      padding-left: 30px;
+    .wp-block-pullquote.wp-block-pullquote {
+      padding-left: 60px;
       background-size: 70px 66px !important;
       background-position: 30px 30px !important;
       text-indent: 60px; } }

--- a/style.css
+++ b/style.css
@@ -475,6 +475,14 @@ table {
 .has-pale-cyan-blue-color.has-pale-cyan-blue-color {
   color: #7ea1b8; }
 
+.entry-content > p,
+.entry-content > ul,
+.entry-content > [class*="wp-block"] {
+  margin-bottom: 30px; }
+
+.entry-content .wp-block-spacer {
+  margin: 0 !important; }
+
 .entry-content .wp-block-button .wp-block-button__link {
   display: inline-block;
   padding: 15px;
@@ -693,6 +701,37 @@ hr {
       background-size: 70px 66px !important;
       background-position: 30px 30px !important;
       text-indent: 60px; } }
+
+.wp-block-quote {
+  margin: 0 0 20px; }
+  .wp-block-quote p {
+    margin: 0; }
+    .wp-block-quote p + p {
+      margin-top: 20px; }
+    .wp-block-quote p:last-of-type {
+      margin-bottom: 20px; }
+  .wp-block-quote cite {
+    padding-left: 30px;
+    background: url("https://wc-us.org/wp-content/uploads/2019/04/text-bubble.svg") top left no-repeat;
+    font-size: 14px;
+    font-size: 1.4rem;
+    color: #747466; }
+  .wp-block-quote.is-style-large {
+    margin-left: -60px;
+    padding: 0 0 0 60px;
+    background: url("https://wc-us.org/wp-content/uploads/2019/04/quotes.svg") top left no-repeat; }
+    @media (max-width: 782px) {
+      .wp-block-quote.is-style-large {
+        margin-left: 0;
+        padding-left: 0;
+        text-indent: 60px; } }
+    .wp-block-quote.is-style-large cite {
+      padding-left: 0;
+      background: none;
+      font-size: 18px;
+      font-size: 1.8rem; }
+      .wp-block-quote.is-style-large cite::before {
+        content: "— "; }
 
 /*--------------------------------------------------------------
 # Forms

--- a/style.css
+++ b/style.css
@@ -1,3 +1,4 @@
+@charset "UTF-8";
 /*!
 Theme Name: WCUS 2019
 Theme URI: http://underscores.me/
@@ -666,6 +667,32 @@ hr {
       .wp-block-latest-posts li a {
         -ms-flex-item-align: end;
             align-self: flex-end; } }
+
+.wp-block-pullquote {
+  background: #303030 url("https://wc-us.org/wp-content/uploads/2019/04/speech.svg") 60px center no-repeat !important;
+  color: #fffffa;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  border-radius: 12px;
+  text-align: left;
+  font-style: italic;
+  padding-left: 240px; }
+  .wp-block-pullquote p {
+    margin: 0; }
+    .wp-block-pullquote p + p {
+      margin-top: 30px; }
+    .wp-block-pullquote p:last-of-type {
+      margin-bottom: 30px; }
+  .wp-block-pullquote cite {
+    color: rgba(255, 255, 250, 0.7); }
+    .wp-block-pullquote cite::before {
+      content: "— "; }
+  @media (max-width: 600px) {
+    .wp-block-pullquote {
+      padding-left: 30px;
+      background-size: 70px 66px !important;
+      background-position: 30px 30px !important;
+      text-indent: 60px; } }
 
 /*--------------------------------------------------------------
 # Forms


### PR DESCRIPTION
Fixes #19 – Adds styles for the pullquote block (same look regardless of "style"), and 2 styles for the quote block, large & regular. This includes some tweaks for smaller screens.

![pq-desktop](https://user-images.githubusercontent.com/541093/56868308-9e2d9180-69be-11e9-923e-a9535478c197.png)

![pq-small](https://user-images.githubusercontent.com/541093/56868223-83a6e880-69bd-11e9-81f9-47d919213eb3.png)

![bq-desktop](https://user-images.githubusercontent.com/541093/56868220-83a6e880-69bd-11e9-80f2-3d9c3cf73d67.png)

![bq-small](https://user-images.githubusercontent.com/541093/56868221-83a6e880-69bd-11e9-9a64-1afc1b773160.png)

