### PR TITLE
Add a custom style “header” for media & text block

### DIFF
--- a/sass/elements/blocks/_media-text.scss
+++ b/sass/elements/blocks/_media-text.scss
@@ -59,4 +59,11 @@
 			background-color: $red;
 		}
 	}
+
+	&.is-media-text-header {
+
+		.wp-block-media-text__content {
+			justify-content: center;
+		}
+	}
 }

--- a/style.css
+++ b/style.css
@@ -627,6 +627,10 @@ hr {
     background-color: #303030; }
   .wp-block-media-text.has-vivid-red-background-color .wp-block-media-text__content {
     background-color: #bd2b2e; }
+  .wp-block-media-text.is-media-text-header .wp-block-media-text__content {
+    -webkit-box-pack: center;
+        -ms-flex-pack: center;
+            justify-content: center; }
 
 .wp-block-latest-posts {
   -webkit-font-smoothing: antialiased;


### PR DESCRIPTION
This adds the `.is-media-text-header` class, which we can add to media & text blocks to center the text.

Before:

<img width="1009" alt="Screen Shot 2019-04-28 at 5 18 23 PM" src="https://user-images.githubusercontent.com/541093/56870203-f6be5800-69d9-11e9-9725-1a84689353b1.png">

After:

<img width="986" alt="Screen Shot 2019-04-28 at 5 19 38 PM" src="https://user-images.githubusercontent.com/541093/56870205-faea7580-69d9-11e9-88bc-8ffc945d0743.png">
