### PR TITLE
Style the image & gallery blocks

### DIFF
--- a/sass/elements/_elements.scss
+++ b/sass/elements/_elements.scss
@@ -39,6 +39,7 @@ hr {
 img {
 	height: auto; /* Make sure images are scaled correctly. */
 	max-width: 100%; /* Adhere to container width. */
+	border-radius: $size__border-radius;
 }
 
 figure {

--- a/sass/elements/blocks/_blocks.scss
+++ b/sass/elements/blocks/_blocks.scss
@@ -93,6 +93,27 @@ hr {
 	}
 }
 
+.wp-block-image {
+
+	figcaption {
+		@include font-size(1.6);
+		color: $mid-brown;
+	}
+}
+
+.wp-block-gallery {
+	margin-left: 0;
+
+	.blocks-gallery-item {
+		border-radius: $size__border-radius;
+		overflow: hidden;
+
+		figcaption {
+			color: $cream;
+		}
+	}
+}
+
 @import "media-text";
 @import "latest-posts";
 @import "pullquote";

--- a/style.css
+++ b/style.css
@@ -426,7 +426,8 @@ img {
   height: auto;
   /* Make sure images are scaled correctly. */
   max-width: 100%;
-  /* Adhere to container width. */ }
+  /* Adhere to container width. */
+  border-radius: 12px; }
 
 figure {
   margin: 1em 0;
@@ -592,6 +593,19 @@ hr {
     font-weight: 700;
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale; }
+
+.wp-block-image figcaption {
+  font-size: 16px;
+  font-size: 1.6rem;
+  color: #747466; }
+
+.wp-block-gallery {
+  margin-left: 0; }
+  .wp-block-gallery .blocks-gallery-item {
+    border-radius: 12px;
+    overflow: hidden; }
+    .wp-block-gallery .blocks-gallery-item figcaption {
+      color: #fffffa; }
 
 .wp-block-media-text {
   margin: 20px 0;


### PR DESCRIPTION
This adds the border radius & caption styling to images and gallery blocks. @melchoyce I swear I saw something about using the mid-brown `#747466` for captions, so I've done that here, but did I make that up?

![Screen Shot 2019-04-29 at 4 53 51 PM](https://user-images.githubusercontent.com/541093/56926327-8b3ebe00-6a9f-11e9-9287-47ae3270c386.png)

This adds the border radius to _all_ images. I think that's accurate - rounded should be the default, and we can override to remove it if needed.