### PR TITLE
Update spacing on alignwide blocks on small screens

### DIFF
--- a/sass/elements/blocks/_latest-posts.scss
+++ b/sass/elements/blocks/_latest-posts.scss
@@ -3,8 +3,22 @@
 	font-family: $font-button;
 	font-weight: 700;
 	margin: spacing(2) 0;
+	padding: 0;
+	display: grid;
+	grid-template-columns: 1fr;
+	grid-gap: spacing(1);
+
+	&.is-grid {
+		display: grid;
+
+		li {
+			margin: 0;
+			width: 100%;
+		}
+	}
 
 	li {
+		width: 100%;
 		background: $grey;
 		color: $white;
 		padding: spacing(2);
@@ -48,5 +62,26 @@
 				align-self: flex-end;
 			}
 		}
+
+		&.columns-2 {
+			grid-template-columns: repeat(2, 1fr);
+		}
+
+		&.columns-3 {
+			grid-template-columns: repeat(3, 1fr);
+		}
+
+		&.columns-4 {
+			grid-template-columns: repeat(4, 1fr);
+		}
+
+		&.columns-5 {
+			grid-template-columns: repeat(5, 1fr);
+		}
+
+		&.columns-6 {
+			grid-template-columns: repeat(6, 1fr);
+		}
+
 	}
 }

--- a/sass/modules/_alignments.scss
+++ b/sass/modules/_alignments.scss
@@ -15,12 +15,13 @@
 	@include center-block;
 }
 
-// .alignwide {}
 .alignfull,
 .alignwide {
-	width: 100vw;
-	margin-left: calc(50% - 50vw);
-	max-width: none;
+	@media (min-width: $size__width--post) {
+		width: 100vw;
+		margin-left: calc(50% - 50vw);
+		max-width: none;
+	}
 
 	img {
 		width: 100%;
@@ -30,10 +31,14 @@
 .alignwide {
 	max-width: $size__width--main;
 
+	@media (min-width: $size__width--post) {
+		max-width: calc(100vw - #{spacing(2) * 2});
+		margin-left: calc((#{$size__width--post + (spacing(2) * 2)} - 100vw) / 2);
+	}
+
 	@media (min-width: $size__width--main) {
 		width: $size__width--main;
 		margin-left: 50%;
 		transform: translateX(-50%);
-		max-width: none;
 	}
 }

--- a/style.css
+++ b/style.css
@@ -1080,24 +1080,29 @@ a {
   margin-left: auto;
   margin-right: auto; }
 
-.alignfull,
-.alignwide {
-  width: 100vw;
-  margin-left: calc(50% - 50vw);
-  max-width: none; }
-  .alignfull img,
-  .alignwide img {
-    width: 100%; }
+@media (min-width: 620px) {
+  .alignfull,
+  .alignwide {
+    width: 100vw;
+    margin-left: calc(50% - 50vw);
+    max-width: none; } }
+
+.alignfull img,
+.alignwide img {
+  width: 100%; }
 
 .alignwide {
   max-width: 940px; }
+  @media (min-width: 620px) {
+    .alignwide {
+      max-width: calc(100vw - 60px);
+      margin-left: calc((680px - 100vw) / 2); } }
   @media (min-width: 940px) {
     .alignwide {
       width: 940px;
       margin-left: 50%;
       -webkit-transform: translateX(-50%);
-              transform: translateX(-50%);
-      max-width: none; } }
+              transform: translateX(-50%); } }
 
 /*--------------------------------------------------------------
 # Clearings

--- a/style.css
+++ b/style.css
@@ -648,8 +648,18 @@ hr {
   -moz-osx-font-smoothing: grayscale;
   font-family: "Nunito", "Tahoma", "Verdana", sans-serif;
   font-weight: 700;
-  margin: 30px 0; }
+  margin: 30px 0;
+  padding: 0;
+  display: grid;
+  grid-template-columns: 1fr;
+  grid-gap: 20px; }
+  .wp-block-latest-posts.is-grid {
+    display: grid; }
+    .wp-block-latest-posts.is-grid li {
+      margin: 0;
+      width: 100%; }
   .wp-block-latest-posts li {
+    width: 100%;
     background: #303030;
     color: #fff;
     padding: 30px;
@@ -680,7 +690,17 @@ hr {
         width: 100%; }
       .wp-block-latest-posts li a {
         -ms-flex-item-align: end;
-            align-self: flex-end; } }
+            align-self: flex-end; }
+    .wp-block-latest-posts.columns-2 {
+      grid-template-columns: repeat(2, 1fr); }
+    .wp-block-latest-posts.columns-3 {
+      grid-template-columns: repeat(3, 1fr); }
+    .wp-block-latest-posts.columns-4 {
+      grid-template-columns: repeat(4, 1fr); }
+    .wp-block-latest-posts.columns-5 {
+      grid-template-columns: repeat(5, 1fr); }
+    .wp-block-latest-posts.columns-6 {
+      grid-template-columns: repeat(6, 1fr); } }
 
 .wp-block-pullquote.wp-block-pullquote {
   background: #303030 url("https://wc-us.org/wp-content/uploads/2019/04/speech.svg") 60px center no-repeat !important;


### PR DESCRIPTION
Fixes #34  – blocks with `alignwide` should still have some space between the edge of the screen. This also fixes an alignment issue where the latest posts block looks off-center due to an extra margin.

<img width="612" alt="Screen Shot 2019-04-29 at 11 15 17 PM" src="https://user-images.githubusercontent.com/541093/56939162-c4ddec00-6ad4-11e9-87e2-144db8c0c0ee.png">
