### PR TITLE
quick fix to get the title aligned with content on archive pages.

### DIFF
--- a/sass/site/primary/_posts-and-pages.scss
+++ b/sass/site/primary/_posts-and-pages.scss
@@ -20,6 +20,17 @@
 	display: inline;
 }
 
+.blog,
+.archive,
+.error404 {
+
+	.entry-header,
+	.page-title {
+		margin: spacing(2) auto 0;
+		max-width: $size__width--post;
+	}
+}
+
 .page,
 .single {
 

--- a/style.css
+++ b/style.css
@@ -1745,6 +1745,15 @@ a {
 .group-blog .byline {
   display: inline; }
 
+.blog .entry-header,
+.blog .page-title,
+.archive .entry-header,
+.archive .page-title,
+.error404 .entry-header,
+.error404 .page-title {
+  margin: 30px auto 0;
+  max-width: 620px; }
+
 .page .entry-header,
 .single .entry-header {
   position: relative;


### PR DESCRIPTION
This just sets the max-width and margin for `.page-title` and `.entry-header` on `.blog`, `.archive`, and `.error404``body` classes.