### PR TITLE
aligning two questions with lots of choices to the top

### DIFF
--- a/sass/site/primary/_tickets.scss
+++ b/sass/site/primary/_tickets.scss
@@ -167,3 +167,8 @@ form[action*="tix_action=attendee_info"] {
 		text-align: right !important;
 	}
 }
+
+.tix-row-question-1296 .tix-left,
+.tix-row-question-1297 .tix-left {
+	vertical-align: top;
+}

--- a/style.css
+++ b/style.css
@@ -2336,6 +2336,10 @@ form[action*="tix_action=attendee_info"] {
   border: none;
   text-align: right !important; }
 
+.tix-row-question-1296 .tix-left,
+.tix-row-question-1297 .tix-left {
+  vertical-align: top; }
+
 /*--------------------------------------------------------------
 ## Comments
 --------------------------------------------------------------*/


### PR DESCRIPTION
Questions with a lot of choices make the question too far down. This aligns those specific questions to the top.

![image](https://user-images.githubusercontent.com/4986487/57003862-514ce500-6b8f-11e9-9a7d-deb2a68b6997.png)
