### PR TITLE
Fixes the alignment of the tag svg for posts

### DIFF
--- a/sass/site/primary/_posts-and-pages.scss
+++ b/sass/site/primary/_posts-and-pages.scss
@@ -140,7 +140,7 @@
 	.tags-links {
 		width: 50%;
 		padding-left: 32px;
-		background: transparent url("#{$icon-tag}") bottom left no-repeat;
+		background: transparent url("#{$icon-tag}") left 3px no-repeat;
 	}
 
 	.edit-link {

--- a/style.css
+++ b/style.css
@@ -1873,7 +1873,7 @@ a {
   .entry-footer .tags-links {
     width: 50%;
     padding-left: 32px;
-    background: transparent url("https://wc-us.org/wp-content/uploads/2019/04/tag.svg") bottom left no-repeat; }
+    background: transparent url("https://wc-us.org/wp-content/uploads/2019/04/tag.svg") left 3px no-repeat; }
   .entry-footer .edit-link {
     text-align: right;
     width: 50%; }


### PR DESCRIPTION
When a post has tags, I think there was some unexpected markup on the page. The design mockup had just shown the tag names, but when tags are added to a post, the word "Tagged" is added above the tag names so that will always be at least two lines high.

This switches the alignment from the `bottom` to 3px from the top.

Fixes #49 