### PR TITLE
Adjusts the post footer meta layout

### DIFF
--- a/sass/abstracts/_assets.scss
+++ b/sass/abstracts/_assets.scss
@@ -12,6 +12,7 @@ $icon-speaking: "https://wc-us.org/wp-content/uploads/2019/04/speech.svg";
 $icon-quote: "https://wc-us.org/wp-content/uploads/2019/04/quotes.svg";
 $icon-text: "https://wc-us.org/wp-content/uploads/2019/04/text-bubble.svg";
 $icon-tag: "https://wc-us.org/wp-content/uploads/2019/04/tag.svg";
+$icon-category: "https://wc-us.org/wp-content/uploads/2019/05/category.svg";
 $icon-arrow-left: "https://wc-us.org/wp-content/uploads/2019/04/arrow-left.svg";
 
 // Other UI assets

--- a/sass/site/primary/_posts-and-pages.scss
+++ b/sass/site/primary/_posts-and-pages.scss
@@ -121,7 +121,8 @@
 }
 
 .entry-footer {
-	display: flex;
+	display: grid;
+	grid-template-columns: auto auto;
 	margin: spacing(2) auto spacing(3);
 	max-width: $size__width--post;
 	color: $mid-brown;
@@ -137,14 +138,28 @@
 		}
 	}
 
-	.tags-links {
-		width: 50%;
+	span:not(.edit-link) {
 		padding-left: 32px;
-		background: transparent url("#{$icon-tag}") left 3px no-repeat;
+		background-color: transparent;
+		background-position: left 3px;
+		background-repeat: no-repeat;
+	}
+
+	.cat-links {
+		background-image: url("#{$icon-category}");
+	}
+
+	.tags-links {
+		grid-row-start: 2;
+		background-image: url("#{$icon-tag}");
+	}
+
+	.comments-link {
+		grid-row-start: 3;
+		background-image: url("#{$icon-text}");
 	}
 
 	.edit-link {
 		text-align: right;
-		width: 50%;
 	}
 }

--- a/sass/site/primary/_posts-and-pages.scss
+++ b/sass/site/primary/_posts-and-pages.scss
@@ -123,6 +123,7 @@
 .entry-footer {
 	display: grid;
 	grid-template-columns: auto auto;
+	grid-row-gap: 5px;
 	margin: spacing(2) auto spacing(3);
 	max-width: $size__width--post;
 	color: $mid-brown;
@@ -150,16 +151,22 @@
 	}
 
 	.tags-links {
-		grid-row-start: 2;
 		background-image: url("#{$icon-tag}");
 	}
 
 	.comments-link {
-		grid-row-start: 3;
 		background-image: url("#{$icon-text}");
 	}
 
 	.edit-link {
 		text-align: right;
+	}
+
+	span:not(.edit-link):nth-of-type(2) {
+		grid-row-start: 2;
+	}
+
+	span:not(.edit-link):nth-of-type(3) {
+		grid-row-start: 2;
 	}
 }

--- a/style.css
+++ b/style.css
@@ -1856,9 +1856,8 @@ a {
   clear: both; }
 
 .entry-footer {
-  display: -webkit-box;
-  display: -ms-flexbox;
-  display: flex;
+  display: grid;
+  grid-template-columns: auto auto;
   margin: 30px auto 60px;
   max-width: 620px;
   color: #747466;
@@ -1870,13 +1869,21 @@ a {
     text-decoration: none; }
     .entry-footer a:hover, .entry-footer a:active, .entry-footer a:focus {
       text-decoration: underline; }
-  .entry-footer .tags-links {
-    width: 50%;
+  .entry-footer span:not(.edit-link) {
     padding-left: 32px;
-    background: transparent url("https://wc-us.org/wp-content/uploads/2019/04/tag.svg") left 3px no-repeat; }
+    background-color: transparent;
+    background-position: left 3px;
+    background-repeat: no-repeat; }
+  .entry-footer .cat-links {
+    background-image: url("https://wc-us.org/wp-content/uploads/2019/05/category.svg"); }
+  .entry-footer .tags-links {
+    grid-row-start: 2;
+    background-image: url("https://wc-us.org/wp-content/uploads/2019/04/tag.svg"); }
+  .entry-footer .comments-link {
+    grid-row-start: 3;
+    background-image: url("https://wc-us.org/wp-content/uploads/2019/04/text-bubble.svg"); }
   .entry-footer .edit-link {
-    text-align: right;
-    width: 50%; }
+    text-align: right; }
 
 body.home .entry-header {
   clip: rect(1px, 1px, 1px, 1px);

--- a/style.css
+++ b/style.css
@@ -1858,6 +1858,7 @@ a {
 .entry-footer {
   display: grid;
   grid-template-columns: auto auto;
+  grid-row-gap: 5px;
   margin: 30px auto 60px;
   max-width: 620px;
   color: #747466;
@@ -1877,13 +1878,15 @@ a {
   .entry-footer .cat-links {
     background-image: url("https://wc-us.org/wp-content/uploads/2019/05/category.svg"); }
   .entry-footer .tags-links {
-    grid-row-start: 2;
     background-image: url("https://wc-us.org/wp-content/uploads/2019/04/tag.svg"); }
   .entry-footer .comments-link {
-    grid-row-start: 3;
     background-image: url("https://wc-us.org/wp-content/uploads/2019/04/text-bubble.svg"); }
   .entry-footer .edit-link {
     text-align: right; }
+  .entry-footer span:not(.edit-link):nth-of-type(2) {
+    grid-row-start: 2; }
+  .entry-footer span:not(.edit-link):nth-of-type(3) {
+    grid-row-start: 2; }
 
 body.home .entry-header {
   clip: rect(1px, 1px, 1px, 1px);


### PR DESCRIPTION
The post footer meta layout had been in columns that looked strange when content wrapped to another line.

Switched from `flexbox` to `grid` here to accommodate the layout for all users. Logged in users get the `.edit-link` element that should align to the top right of the `.entry-footer` container.

Also added icons for each piece of post footer meta. `tags` had an existing icon, but `categories` and `comments` needed icons.

Potential fix for #49 