### PR TITLE
Ticket page tweaks

### DIFF
--- a/sass/site/primary/_tickets.scss
+++ b/sass/site/primary/_tickets.scss
@@ -1,66 +1,22 @@
+body.page-slug-tickets {
+
+	.entry-content {
+		max-width: $size__width--main;
+
+		> *:not(div) {
+			margin-left: auto;
+			margin-right: auto;
+			max-width: $size__width--post;
+		}
+	}
+}
+
 #tix {
 
 	.tix-submit {
 
 		.tix-checkout-button {
 			@include button;
-		}
-	}
-
-	@media (max-width: $breakpoint-content-width) {
-		max-width: 100vw;
-		overflow: scroll;
-	}
-}
-
-form[action*="tix_action=attendee_info"] {
-	max-width: 100%;
-	width: 100%;
-	margin-left: 0;
-
-	@media (min-width: $breakpoint-content-width) {
-		width: $size__width--main;
-		max-width: calc(100vw - #{spacing(2) * 2});
-		margin-left: calc((#{$breakpoint-content-width} - 100vw) / 2);
-	}
-
-	@media (min-width: $size__width--main) {
-		width: $size__width--main;
-		max-width: none;
-		margin-left: 50%;
-		transform: translateX(-50%);
-	}
-}
-
-th.tix-column-price,
-th.tix-column-quantity {
-	@media (max-width: $breakpoint-content-width) {
-		display: none;
-	}
-}
-
-td {
-	@media (max-width: $breakpoint-content-width) {
-
-		&.tix-column-description,
-		&.tix-column-price,
-		&.tix-column-quantity {
-			display: block;
-			padding-right: 0;
-		}
-
-		&.tix-column-price {
-
-			&::before {
-				content: "Price:";
-			}
-		}
-
-		&.tix-column-quantity {
-
-			&::before {
-				content: "Quantity:";
-			}
 		}
 	}
 }
@@ -93,6 +49,67 @@ td {
 	.tix-column-remaining {
 		display: none;
 	}
+
+	@media (max-width: $breakpoint-content-width) {
+		display: block;
+
+		th.tix-column-description,
+		th.tix-column-per-ticket,
+		th.tix-column-price,
+		th.tix-column-quantity {
+			display: none;
+		}
+
+		td {
+
+			&.tix-column-description,
+			&.tix-column-per-ticket,
+			&.tix-column-price,
+			&.tix-column-quantity {
+				display: block;
+				padding-right: 0;
+				padding-left: 0;
+				text-align: left;
+				border-top: none;
+			}
+
+			&.tix-column-per-ticket,
+			&.tix-column-price,
+			&.tix-column-quantity {
+				padding-top: 0;
+				border-top: none;
+			}
+
+			&.tix-column-description {
+				width: 100%;
+			}
+
+			&.tix-column-per-ticket {
+
+				&::before {
+					content: "Price per ticket: ";
+				}
+			}
+
+			&.tix-column-price {
+
+				&::before {
+					content: "Price: ";
+					font-weight: 400;
+				}
+			}
+
+			&.tix-column-quantity {
+				padding-top: 0;
+				border-bottom: 1px solid rgba($light-blue, 0.2);
+
+				&::before {
+					content: "Quantity:";
+					margin-right: spacing(0);
+				}
+			}
+		}
+	}
 }
 
 .tix-left {
@@ -119,7 +136,56 @@ td {
 
 .tix-order-summary {
 	margin-bottom: spacing(4);
+
+	@media (max-width: $breakpoint-content-width) {
+		display: block;
+
+		td.tix-column-quantity {
+			border-bottom: none;
+		}
+
+		.tix-row-total {
+
+			td[colspan] {
+				display: none;
+			}
+
+			td {
+				padding-left: 0;
+				text-align: left;
+
+				&::before {
+					content: "Total: ";
+				}
+			}
+		}
+	}
 }
+
+.tix-ticket-form,
+.tix-private-form,
+.tix-attendee-form,
+.tix-receipt-form {
+
+	input[type="text"],
+	input[type="email"],
+	input[type="url"],
+	textarea,
+	select {
+		width: 100%;
+	}
+
+	select {
+		width: 100%;
+		height: 57px;
+	}
+
+	input[type="radio"],
+	input[type="checkbox"] {
+		margin-right: 0.5em;
+	}
+}
+
 
 .tix-attendee-form {
 
@@ -152,27 +218,21 @@ td {
 	}
 }
 
-.tix-ticket-form,
-.tix-private-form,
-.tix-attendee-form,
-.tix-receipt-form {
-
-	input[type="text"],
-	input[type="email"],
-	input[type="url"],
-	textarea,
-	select {
+.tix-ticket-form {
+	@media (max-width: $breakpoint-small) {
+		display: block;
 		width: 100%;
-	}
 
-	select {
-		width: 100%;
-		height: 57px;
-	}
+		th + th {
+			display: none;
+		}
 
-	input[type="radio"],
-	input[type="checkbox"] {
-		margin-right: 0.5em;
+		td {
+			display: block;
+			width: 100% !important;
+			padding-left: 0;
+			padding-right: 0;
+		}
 	}
 }
 
@@ -202,9 +262,11 @@ td {
 
 	#tix-coupon-input {
 		width: 100%;
+		margin-bottom: spacing(0);
 
 		@media (min-width: $breakpoint-content-width) {
 			width: calc(100% - 330px);
+			margin-bottom: 0;
 		}
 	}
 }

--- a/style.css
+++ b/style.css
@@ -2141,6 +2141,13 @@ body.home .entry-header {
       .wcb_widget_sponsors .wcorg-sponsor-level-bronze h2 {
         grid-column-end: span 3; } }
 
+body.page-slug-tickets .entry-content {
+  max-width: 940px; }
+  body.page-slug-tickets .entry-content > *:not(div) {
+    margin-left: auto;
+    margin-right: auto;
+    max-width: 620px; }
+
 #tix .tix-submit .tix-checkout-button {
   display: inline-block;
   padding: 15px;
@@ -2166,42 +2173,6 @@ body.home .entry-header {
     -webkit-transform: translateY(1px);
             transform: translateY(1px); }
 
-@media (max-width: 680px) {
-  #tix {
-    max-width: 100vw;
-    overflow: scroll; } }
-
-form[action*="tix_action=attendee_info"] {
-  max-width: 100%;
-  width: 100%;
-  margin-left: 0; }
-  @media (min-width: 680px) {
-    form[action*="tix_action=attendee_info"] {
-      width: 940px;
-      max-width: calc(100vw - 60px);
-      margin-left: calc((680px - 100vw) / 2); } }
-  @media (min-width: 940px) {
-    form[action*="tix_action=attendee_info"] {
-      width: 940px;
-      max-width: none;
-      margin-left: 50%;
-      -webkit-transform: translateX(-50%);
-              transform: translateX(-50%); } }
-
-@media (max-width: 680px) {
-  th.tix-column-price,
-  th.tix-column-quantity {
-    display: none; } }
-
-@media (max-width: 680px) {
-  td.tix-column-description, td.tix-column-price, td.tix-column-quantity {
-    display: block;
-    padding-right: 0; }
-  td.tix-column-price::before {
-    content: "Price:"; }
-  td.tix-column-quantity::before {
-    content: "Quantity:"; } }
-
 .tix_tickets_table {
   border: 4px dotted #9e8b7e;
   border-left-width: 0;
@@ -2219,6 +2190,36 @@ form[action*="tix_action=attendee_info"] {
     min-width: 4em; }
   .tix_tickets_table .tix-column-remaining {
     display: none; }
+  @media (max-width: 680px) {
+    .tix_tickets_table {
+      display: block; }
+      .tix_tickets_table th.tix-column-description,
+      .tix_tickets_table th.tix-column-per-ticket,
+      .tix_tickets_table th.tix-column-price,
+      .tix_tickets_table th.tix-column-quantity {
+        display: none; }
+      .tix_tickets_table td.tix-column-description, .tix_tickets_table td.tix-column-per-ticket, .tix_tickets_table td.tix-column-price, .tix_tickets_table td.tix-column-quantity {
+        display: block;
+        padding-right: 0;
+        padding-left: 0;
+        text-align: left;
+        border-top: none; }
+      .tix_tickets_table td.tix-column-per-ticket, .tix_tickets_table td.tix-column-price, .tix_tickets_table td.tix-column-quantity {
+        padding-top: 0;
+        border-top: none; }
+      .tix_tickets_table td.tix-column-description {
+        width: 100%; }
+      .tix_tickets_table td.tix-column-per-ticket::before {
+        content: "Price per ticket: "; }
+      .tix_tickets_table td.tix-column-price::before {
+        content: "Price: ";
+        font-weight: 400; }
+      .tix_tickets_table td.tix-column-quantity {
+        padding-top: 0;
+        border-bottom: 1px solid rgba(126, 161, 184, 0.2); }
+        .tix_tickets_table td.tix-column-quantity::before {
+          content: "Quantity:";
+          margin-right: 15px; } }
 
 .tix-left {
   font-weight: 700; }
@@ -2236,29 +2237,18 @@ form[action*="tix_action=attendee_info"] {
 
 .tix-order-summary {
   margin-bottom: 90px; }
-
-.tix-attendee-form tbody tr th {
-  text-align: left;
-  font-family: "Nunito", "Tahoma", "Verdana", sans-serif;
-  font-size: 28px;
-  font-size: 2.8rem;
-  line-height: 1.3;
-  font-weight: 900; }
-
-.tix-attendee-form td {
-  border: none;
-  vertical-align: middle; }
-
-@media (max-width: 600px) {
-  .tix-attendee-form {
-    display: block; }
-    .tix-attendee-form td {
-      display: block;
-      width: 100% !important;
-      padding-left: 0;
-      padding-right: 0; }
-      .tix-attendee-form td.tix-left {
-        padding-bottom: 0; } }
+  @media (max-width: 680px) {
+    .tix-order-summary {
+      display: block; }
+      .tix-order-summary td.tix-column-quantity {
+        border-bottom: none; }
+      .tix-order-summary .tix-row-total td[colspan] {
+        display: none; }
+      .tix-order-summary .tix-row-total td {
+        padding-left: 0;
+        text-align: left; }
+        .tix-order-summary .tix-row-total td::before {
+          content: "Total: "; } }
 
 .tix-ticket-form input[type="text"],
 .tix-ticket-form input[type="email"],
@@ -2298,6 +2288,41 @@ form[action*="tix_action=attendee_info"] {
 .tix-receipt-form input[type="radio"],
 .tix-receipt-form input[type="checkbox"] {
   margin-right: 0.5em; }
+
+.tix-attendee-form tbody tr th {
+  text-align: left;
+  font-family: "Nunito", "Tahoma", "Verdana", sans-serif;
+  font-size: 28px;
+  font-size: 2.8rem;
+  line-height: 1.3;
+  font-weight: 900; }
+
+.tix-attendee-form td {
+  border: none;
+  vertical-align: middle; }
+
+@media (max-width: 600px) {
+  .tix-attendee-form {
+    display: block; }
+    .tix-attendee-form td {
+      display: block;
+      width: 100% !important;
+      padding-left: 0;
+      padding-right: 0; }
+      .tix-attendee-form td.tix-left {
+        padding-bottom: 0; } }
+
+@media (max-width: 600px) {
+  .tix-ticket-form {
+    display: block;
+    width: 100%; }
+    .tix-ticket-form th + th {
+      display: none; }
+    .tix-ticket-form td {
+      display: block;
+      width: 100% !important;
+      padding-left: 0;
+      padding-right: 0; } }
 
 #tix-coupon-link {
   display: inline-block;
@@ -2347,10 +2372,12 @@ form[action*="tix_action=attendee_info"] {
       margin-right: 60px; } }
 
 #tix-coupon-container #tix-coupon-input {
-  width: 100%; }
+  width: 100%;
+  margin-bottom: 15px; }
   @media (min-width: 680px) {
     #tix-coupon-container #tix-coupon-input {
-      width: calc(100% - 330px); } }
+      width: calc(100% - 330px);
+      margin-bottom: 0; } }
 
 .tix-row-coupon {
   font-weight: 700; }


### PR DESCRIPTION
All ticket pages are now wide, with width fixed on the content; tables now drop to single-column on smaller screens (cutoff is 600 or 680, depending on screen)

Fixes #53, fixes #57 

![Screen Shot 2019-05-01 at 2 20 08 PM](https://user-images.githubusercontent.com/541093/57033955-47bd8e80-6c1c-11e9-849a-ba7604a43a8a.png)

![us wordcamp test_tickets_](https://user-images.githubusercontent.com/541093/57033889-1f359480-6c1c-11e9-8b82-f4274b2430e8.png)

![us wordcamp test_tickets__tix_action=attendee_info](https://user-images.githubusercontent.com/541093/57033888-1e9cfe00-6c1c-11e9-99c7-58395370beb1.png)
