### PR TITLE
Switch the breakpoint for homepage widgets

### DIFF
--- a/sass/site/secondary/_home-info.scss
+++ b/sass/site/secondary/_home-info.scss
@@ -37,7 +37,7 @@
 		grid-template-columns: repeat(2, 1fr);
 	}
 
-	@media (max-width: $breakpoint-small) {
+	@media (max-width: $breakpoint-mobile) {
 		grid-template-columns: repeat(1, 1fr);
 	}
 

--- a/style.css
+++ b/style.css
@@ -1484,7 +1484,7 @@ a {
   @media (max-width: 782px) {
     #content-widget-3 {
       grid-template-columns: repeat(2, 1fr); } }
-  @media (max-width: 600px) {
+  @media (max-width: 480px) {
     #content-widget-3 {
       grid-template-columns: repeat(1, 1fr); } }
   #content-widget-3 .widget a {


### PR DESCRIPTION
Fixes #54 – Just changes the breakpoint for when the widgets switch to 1 column (480, not 600).

At 481px:

![Screen Shot 2019-05-04 at 1 16 37 PM](https://user-images.githubusercontent.com/541093/57182594-dfb2b680-6e6e-11e9-8ee8-3c267c5fbe24.png)
