### PR TITLE
Add the organizers page style

### DIFF
--- a/sass/site/_site.scss
+++ b/sass/site/_site.scss
@@ -8,6 +8,7 @@
 @import "primary/sponsors";
 @import "primary/tickets";
 @import "primary/attendees";
+@import "primary/organizers";
 @import "primary/404";
 
 /*--------------------------------------------------------------

--- a/sass/site/primary/_organizers.scss
+++ b/sass/site/primary/_organizers.scss
@@ -1,0 +1,32 @@
+.wcorg-organizers {
+
+	.wcorg-organizer {
+		position: relative;
+		margin-bottom: spacing(4)/2;
+
+		> h2 {
+			@include font-size( $font__size--level-3 );
+			line-height: 1.3;
+			font-weight: 900;
+			color: $color__text;
+		}
+
+		@media (min-width: $breakpoint-small) {
+			padding-left: 96px + spacing(2);
+		}
+	}
+
+	.avatar {
+		float: left;
+		margin-right: spacing(1);
+		border-radius: 50%;
+
+		@media (min-width: $breakpoint-small) {
+			position: absolute;
+			top: 0;
+			left: 0;
+			margin-right: 0;
+			float: none;
+		}
+	}
+}

--- a/style.css
+++ b/style.css
@@ -2701,6 +2701,31 @@ body.page-slug-attendees #tix-attendees {
           float: none;
           margin-right: 0; } }
 
+.wcorg-organizers .wcorg-organizer {
+  position: relative;
+  margin-bottom: 45px; }
+  .wcorg-organizers .wcorg-organizer > h2 {
+    font-size: 20px;
+    font-size: 2rem;
+    line-height: 1.3;
+    font-weight: 900;
+    color: #303030; }
+  @media (min-width: 600px) {
+    .wcorg-organizers .wcorg-organizer {
+      padding-left: 126px; } }
+
+.wcorg-organizers .avatar {
+  float: left;
+  margin-right: 20px;
+  border-radius: 50%; }
+  @media (min-width: 600px) {
+    .wcorg-organizers .avatar {
+      position: absolute;
+      top: 0;
+      left: 0;
+      margin-right: 0;
+      float: none; } }
+
 .error404 .page-content .search-form,
 .error404 .page-content .widget {
   margin-bottom: 60px; }


### PR DESCRIPTION
Adds the styles for the Organizers page, fixes #60  (for some reason, my test site doesn't have avatars)

<img width="784" alt="Screen Shot 2019-05-26 at 11 19 31 AM" src="https://user-images.githubusercontent.com/541093/58383732-3c098180-7fa8-11e9-98fa-7203ae991e5f.png">

Smaller screens:

<img width="437" alt="Screen Shot 2019-05-26 at 11 19 12 AM" src="https://user-images.githubusercontent.com/541093/58383731-3b70eb00-7fa8-11e9-93fa-14d42d24888a.png">
