### PR TITLE
Move over Customizer CSS

### DIFF
--- a/sass/forms/_fields.scss
+++ b/sass/forms/_fields.scss
@@ -38,3 +38,27 @@ select {
 		@include dotted-outline;
 	}
 }
+
+// Specificity hack :(
+.contact-form.contact-form {
+
+	input[type="email"],
+	input[type="text"],
+	input[type="url"],
+	textarea {
+		width: 100%;
+		max-width: 100%;
+	}
+
+	select {
+		min-width: 80px;
+	}
+
+	select,
+	input[type="email"],
+	input[type="text"],
+	input[type="url"],
+	textarea {
+		margin-bottom: 30px;
+	}
+}

--- a/sass/site/primary/_posts-and-pages.scss
+++ b/sass/site/primary/_posts-and-pages.scss
@@ -52,6 +52,10 @@
 			width: 100%;
 			@include font-size( $font__size--header );
 			letter-spacing: 1px;
+
+			@media (max-width: $breakpoint-large) {
+				@include font-size( $font__size--level-1 );
+			}
 		}
 	}
 }

--- a/sass/site/primary/_tickets.scss
+++ b/sass/site/primary/_tickets.scss
@@ -55,6 +55,29 @@ body.page-slug-tickets {
 		display: none;
 	}
 
+	th[colspan="2"] {
+		text-align: left;
+	}
+
+	// Align specific question-fields to the left.
+	.tix-row-question-1300,
+	.tix-row-question-1291,
+	.tix-row-question-1318,
+	.tix-row-question-1296,
+	.tix-row-question-1297,
+	.tix-row-question-1298,
+	.tix-row-question-1299,
+	.tix-row-question-1301,
+	.tix-row-privacy,
+	.tix-row-allergy,
+	.tix-row-accommodations,
+	.tix-row-coc {
+
+		.tix-right {
+			text-align: left;
+		}
+	}
+
 	@media (max-width: $breakpoint-content-width) {
 		display: block;
 

--- a/sass/site/secondary/_subscribe.scss
+++ b/sass/site/secondary/_subscribe.scss
@@ -116,3 +116,12 @@
 		}
 	}
 }
+
+p#subscribe-email {
+	display: inline-block;
+	width: 80%;
+}
+
+p#subscribe-submit {
+	display: inline-block;
+}

--- a/style.css
+++ b/style.css
@@ -949,6 +949,23 @@ select {
     outline: 2px dotted #303030;
     outline-offset: 2px; }
 
+.contact-form.contact-form input[type="email"],
+.contact-form.contact-form input[type="text"],
+.contact-form.contact-form input[type="url"],
+.contact-form.contact-form textarea {
+  width: 100%;
+  max-width: 100%; }
+
+.contact-form.contact-form select {
+  min-width: 80px; }
+
+.contact-form.contact-form select,
+.contact-form.contact-form input[type="email"],
+.contact-form.contact-form input[type="text"],
+.contact-form.contact-form input[type="url"],
+.contact-form.contact-form textarea {
+  margin-bottom: 30px; }
+
 /*--------------------------------------------------------------
 # Navigation
 --------------------------------------------------------------*/
@@ -1746,6 +1763,13 @@ a {
       .widget_blog_subscription #subscribe-submit button {
         width: 100%; } }
 
+p#subscribe-email {
+  display: inline-block;
+  width: 80%; }
+
+p#subscribe-submit {
+  display: inline-block; }
+
 .jetpack_widget_social_icons .widget-title {
   margin: 0;
   display: inline-block;
@@ -1998,6 +2022,11 @@ a {
     font-size: 48px;
     font-size: 4.8rem;
     letter-spacing: 1px; }
+    @media (max-width: 960px) {
+      .page .entry-header .entry-title,
+      .single .entry-header .entry-title {
+        font-size: 36px;
+        font-size: 3.6rem; } }
 
 .single .entry-header {
   padding-top: 90px;
@@ -2415,6 +2444,21 @@ body.page-slug-tickets .entry-content {
     min-width: 4em; }
   .tix_tickets_table .tix-column-remaining {
     display: none; }
+  .tix_tickets_table th[colspan="2"] {
+    text-align: left; }
+  .tix_tickets_table .tix-row-question-1300 .tix-right,
+  .tix_tickets_table .tix-row-question-1291 .tix-right,
+  .tix_tickets_table .tix-row-question-1318 .tix-right,
+  .tix_tickets_table .tix-row-question-1296 .tix-right,
+  .tix_tickets_table .tix-row-question-1297 .tix-right,
+  .tix_tickets_table .tix-row-question-1298 .tix-right,
+  .tix_tickets_table .tix-row-question-1299 .tix-right,
+  .tix_tickets_table .tix-row-question-1301 .tix-right,
+  .tix_tickets_table .tix-row-privacy .tix-right,
+  .tix_tickets_table .tix-row-allergy .tix-right,
+  .tix_tickets_table .tix-row-accommodations .tix-right,
+  .tix_tickets_table .tix-row-coc .tix-right {
+    text-align: left; }
   @media (max-width: 680px) {
     .tix_tickets_table {
       display: block; }


### PR DESCRIPTION
To keep all the CSS in one place, let's move the customizer styles into the theme (designers can still tweak things in the customizer, we can keep moving over css).

- Ticket question alignment
- Shrink the single page title text size on smaller screens
- Full-width the contact form fields
- Alignment of subscribe form

All this CSS was in-use in the customizer, so it doesn't need an in-depth review - just make sure nothing's awful 🙂 
