### PR TITLE
Add single session page styles

### DIFF
--- a/sass/navigation/_menus.scss
+++ b/sass/navigation/_menus.scss
@@ -309,6 +309,10 @@
 
 	.nav-links {
 		display: flex;
+
+		div:first-child:last-child {
+			width: 100%;
+		}
 	}
 
 	.nav-previous {

--- a/sass/site/_site.scss
+++ b/sass/site/_site.scss
@@ -10,6 +10,7 @@
 @import "primary/attendees";
 @import "primary/organizers";
 @import "primary/speakers";
+@import "primary/sessions";
 @import "primary/community-spotlight";
 @import "primary/404";
 

--- a/sass/site/primary/_sessions.scss
+++ b/sass/site/primary/_sessions.scss
@@ -1,0 +1,31 @@
+body.single-wcb_session {
+
+	#session-speaker-names {
+		padding: 0;
+	}
+
+	.session-categories-links {
+		display: inline-block;
+		height: 24px;
+		padding-left: 32px;
+		background-image: url("#{$icon-tag}");
+		background-color: transparent;
+		background-position: left 3px;
+		background-repeat: no-repeat;
+		font-weight: 700;
+		@include font-size(1.6);
+
+		a {
+			color: $mid-brown;
+			text-decoration: none;
+
+			@include hover-state {
+				text-decoration: underline;
+			}
+		}
+	}
+
+	.entry-footer {
+		display: none;
+	}
+}

--- a/style.css
+++ b/style.css
@@ -1316,6 +1316,10 @@ a {
     display: -webkit-box;
     display: -ms-flexbox;
     display: flex; }
+    .comment-navigation .nav-links div:first-child:last-child,
+    .posts-navigation .nav-links div:first-child:last-child,
+    .post-navigation .nav-links div:first-child:last-child {
+      width: 100%; }
   .comment-navigation .nav-previous,
   .posts-navigation .nav-previous,
   .post-navigation .nav-previous {
@@ -2914,6 +2918,29 @@ body.single-wcb_speaker .speaker-avatar {
     top: 0;
     bottom: 0;
     right: 0; }
+
+body.single-wcb_session #session-speaker-names {
+  padding: 0; }
+
+body.single-wcb_session .session-categories-links {
+  display: inline-block;
+  height: 24px;
+  padding-left: 32px;
+  background-image: url("https://wc-us.org/wp-content/uploads/2019/04/tag.svg");
+  background-color: transparent;
+  background-position: left 3px;
+  background-repeat: no-repeat;
+  font-weight: 700;
+  font-size: 16px;
+  font-size: 1.6rem; }
+  body.single-wcb_session .session-categories-links a {
+    color: #747466;
+    text-decoration: none; }
+    body.single-wcb_session .session-categories-links a:hover, body.single-wcb_session .session-categories-links a:active, body.single-wcb_session .session-categories-links a:focus {
+      text-decoration: underline; }
+
+body.single-wcb_session .entry-footer {
+  display: none; }
 
 .community-spotlight {
   background: #003b63;


### PR DESCRIPTION
Fixes #89 – We're limited in page structure, so unfortunately speaker name comes before the session details and it didn't make as much sense to me to use the separator style between them here. 

<img width="669" alt="Screen Shot 2019-08-04 at 12 32 43 PM" src="https://user-images.githubusercontent.com/541093/62426609-00301e00-b6b5-11e9-9c30-e76c4baf2822.png">
