### PR TITLE
First pass at schedule styles

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2119,8 +2119,7 @@
           "version": "2.1.1",
           "resolved": false,
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -2144,15 +2143,13 @@
           "version": "1.0.0",
           "resolved": false,
           "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "resolved": false,
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2167,22 +2164,19 @@
           "version": "1.1.0",
           "resolved": false,
           "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "resolved": false,
           "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "resolved": false,
           "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2311,8 +2305,7 @@
           "version": "2.0.3",
           "resolved": false,
           "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2326,7 +2319,6 @@
           "resolved": false,
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2343,7 +2335,6 @@
           "resolved": false,
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2359,7 +2350,6 @@
           "version": "2.3.5",
           "resolved": false,
           "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -2467,8 +2457,7 @@
           "version": "1.0.1",
           "resolved": false,
           "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2482,7 +2471,6 @@
           "resolved": false,
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2577,8 +2565,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "resolved": false,
-          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-          "optional": true
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -2620,7 +2607,6 @@
           "resolved": false,
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -2642,7 +2628,6 @@
           "resolved": false,
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -2675,14 +2660,12 @@
           "version": "1.0.2",
           "resolved": false,
           "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "resolved": false,
-          "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
-          "optional": true
+          "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A=="
         }
       }
     },
@@ -4314,7 +4297,6 @@
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz",
       "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
       "dev": true,
-      "optional": true,
       "requires": {
         "safe-buffer": "^5.1.2",
         "yallist": "^3.0.0"
@@ -4324,8 +4306,7 @@
           "version": "3.0.3",
           "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
           "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },

--- a/sass/abstracts/_structure.scss
+++ b/sass/abstracts/_structure.scss
@@ -1,6 +1,7 @@
 $size__width--nav: 1240px;
 $size__width--main: 940px;
 $size__width--post: 620px;
+$size__width--schedule: 1240px; // schedule uses the full content width
 
 $size__height--nav: 73px;
 $size__height--wave: 95px;

--- a/sass/site/_site.scss
+++ b/sass/site/_site.scss
@@ -13,6 +13,7 @@
 @import "primary/sessions";
 @import "primary/community-spotlight";
 @import "primary/404";
+@import "primary/schedule";
 
 /*--------------------------------------------------------------
 ## Comments

--- a/sass/site/primary/_schedule.scss
+++ b/sass/site/primary/_schedule.scss
@@ -1,0 +1,181 @@
+body.page-slug-schedule {
+
+	.schedule-anchors {
+		font-weight: 700;
+		margin-bottom: spacing(3);
+
+		img {
+			margin: 0 7px;
+			vertical-align: middle;
+		}
+	}
+
+	table.wcpt-schedule {
+		margin-bottom: spacing(4);
+	}
+}
+
+// Define some shared styles using variables for consistency.
+$border-style: 1px solid #e5eced; // $light-blue at 20% opacity, hex-ified to prevent overlap from making a darker color.
+$header-bg: rgba($light-blue, 0.05);
+
+table.wcpt-schedule {
+	width: $size__width--schedule;
+	margin-left: 50%;
+	transform: translateX(-50%);
+	border-bottom: $border-style;
+	border-right: $border-style;
+	table-layout: fixed;
+
+	th,
+	td {
+		padding: spacing(0) spacing(1);
+		border: none;
+		border-top: $border-style;
+		border-left: $border-style;
+		@include font-size( 1.6 );
+	}
+
+	th {
+		font-family: $font-header;
+		@include font-size( 2 );
+		line-height: $font__line-height--header;
+		font-weight: 900;
+		text-align: center;
+		background: $header-bg;
+	}
+
+	.wcpt-col-time,
+	.wcpt-time {
+		background: $header-bg;
+		width: 6em;
+	}
+
+	.wcpt-session-speakers {
+		display: block;
+		margin-top: spacing(0) / 2;
+		color: $mid-brown;
+		font-weight: 700;
+	}
+
+	.wcpt-session-empty {
+		border-top: none;
+	}
+
+	td {
+
+		// Anything with a colspan > 1 should be centered, it spans multiple tracks.
+		&[colspan]:not([colspan="1"]) {
+			text-align: center;
+		}
+
+		div.wcb-session-favourite-icon a.fav-session-button {
+			border: none;
+			color: rgba($light-blue, 0.5) !important;
+
+			&:hover {
+				color: $light-blue !important;
+			}
+		}
+
+		&.wcb-favourite-session {
+			background: transparent;
+
+			div.wcb-session-favourite-icon a.fav-session-button {
+				color: $light-red !important;
+
+				&:hover {
+					color: rgba($light-red, 0.6) !important;
+				}
+			}
+		}
+	}
+
+	@media (max-width: $breakpoint-wide) {
+		width: 100vw;
+		margin-left: calc(50% - 50vw);
+		transform: translateX(0);
+		max-width: none;
+	}
+
+	@media (max-width: $breakpoint-large) {
+		border: none;
+		width: 100%;
+		margin-left: 0;
+
+		thead {
+			display: none;
+		}
+
+		tbody,
+		tr,
+		th,
+		td {
+			display: block;
+		}
+
+		tr {
+			margin-bottom: spacing(1);
+			border: $border-style;
+			border-bottom: none;
+		}
+
+		td {
+			border: none;
+			border-bottom: $border-style;
+
+			&.wcpt-session-empty {
+				display: none;
+			}
+		}
+
+		.wcpt-time {
+			padding: spacing(1);
+			font-family: $font-header;
+			@include font-size( 2 );
+			line-height: $font__line-height--header;
+			text-align: center;
+			border-bottom: $border-style;
+			background: $header-bg;
+			width: 100%;
+		}
+
+		.wcpt-session-type-session {
+			margin-bottom: 0;
+
+			&::before {
+				@include font-size( 1.6 );
+				color: $color__text;
+				border: none;
+				content: attr(data-track-title);
+				display: block;
+				margin: 0;
+				padding: 0;
+
+				.global-session & {
+					display: none;
+				}
+			}
+		}
+
+		.wcpt-session-title {
+			display: block;
+			margin: spacing(0) 0;
+			padding: 0;
+		}
+
+		.wcpt-session-speakers {
+			display: block;
+			padding: 0;
+
+			&::before {
+				content: "Speaker: ";
+				font-style: normal;
+			}
+
+			a {
+				color: #21759b;
+			}
+		}
+	}
+}

--- a/sass/site/primary/_schedule.scss
+++ b/sass/site/primary/_schedule.scss
@@ -34,6 +34,7 @@ table.wcpt-schedule {
 		border-top: $border-style;
 		border-left: $border-style;
 		@include font-size( 1.6 );
+		vertical-align: top;
 	}
 
 	th {
@@ -43,12 +44,14 @@ table.wcpt-schedule {
 		font-weight: 900;
 		text-align: center;
 		background: $header-bg;
+		vertical-align: middle;
 	}
 
 	.wcpt-col-time,
 	.wcpt-time {
 		background: $header-bg;
 		width: 6em;
+		text-align: left;
 	}
 
 	.wcpt-session-speakers {
@@ -67,6 +70,10 @@ table.wcpt-schedule {
 		// Anything with a colspan > 1 should be centered, it spans multiple tracks.
 		&[colspan]:not([colspan="1"]) {
 			text-align: center;
+		}
+
+		&[colspan="6"]:not(.wcb-session-opening-remarks) {
+			background: $header-bg;
 		}
 
 		div.wcb-session-favourite-icon a.fav-session-button {

--- a/style.css
+++ b/style.css
@@ -3000,6 +3000,128 @@ body.single-wcb_session .entry-footer {
 .error404 .page-content .search-field {
   width: calc(100% - 110px); }
 
+body.page-slug-schedule .schedule-anchors {
+  font-weight: 700;
+  margin-bottom: 60px; }
+  body.page-slug-schedule .schedule-anchors img {
+    margin: 0 7px;
+    vertical-align: middle; }
+
+body.page-slug-schedule table.wcpt-schedule {
+  margin-bottom: 90px; }
+
+table.wcpt-schedule {
+  width: 1240px;
+  margin-left: 50%;
+  -webkit-transform: translateX(-50%);
+          transform: translateX(-50%);
+  border-bottom: 1px solid #e5eced;
+  border-right: 1px solid #e5eced;
+  table-layout: fixed; }
+  table.wcpt-schedule th,
+  table.wcpt-schedule td {
+    padding: 15px 20px;
+    border: none;
+    border-top: 1px solid #e5eced;
+    border-left: 1px solid #e5eced;
+    font-size: 16px;
+    font-size: 1.6rem; }
+  table.wcpt-schedule th {
+    font-family: "Nunito", "Tahoma", "Verdana", sans-serif;
+    font-size: 20px;
+    font-size: 2rem;
+    line-height: 1.3;
+    font-weight: 900;
+    text-align: center;
+    background: rgba(126, 161, 184, 0.05); }
+  table.wcpt-schedule .wcpt-col-time,
+  table.wcpt-schedule .wcpt-time {
+    background: rgba(126, 161, 184, 0.05);
+    width: 6em; }
+  table.wcpt-schedule .wcpt-session-speakers {
+    display: block;
+    margin-top: 7.5px;
+    color: #747466;
+    font-weight: 700; }
+  table.wcpt-schedule .wcpt-session-empty {
+    border-top: none; }
+  table.wcpt-schedule td[colspan]:not([colspan="1"]) {
+    text-align: center; }
+  table.wcpt-schedule td div.wcb-session-favourite-icon a.fav-session-button {
+    border: none;
+    color: rgba(126, 161, 184, 0.5) !important; }
+    table.wcpt-schedule td div.wcb-session-favourite-icon a.fav-session-button:hover {
+      color: #7ea1b8 !important; }
+  table.wcpt-schedule td.wcb-favourite-session {
+    background: transparent; }
+    table.wcpt-schedule td.wcb-favourite-session div.wcb-session-favourite-icon a.fav-session-button {
+      color: #ee383b !important; }
+      table.wcpt-schedule td.wcb-favourite-session div.wcb-session-favourite-icon a.fav-session-button:hover {
+        color: rgba(238, 56, 59, 0.6) !important; }
+  @media (max-width: 1280px) {
+    table.wcpt-schedule {
+      width: 100vw;
+      margin-left: calc(50% - 50vw);
+      -webkit-transform: translateX(0);
+              transform: translateX(0);
+      max-width: none; } }
+  @media (max-width: 960px) {
+    table.wcpt-schedule {
+      border: none;
+      width: 100%;
+      margin-left: 0; }
+      table.wcpt-schedule thead {
+        display: none; }
+      table.wcpt-schedule tbody,
+      table.wcpt-schedule tr,
+      table.wcpt-schedule th,
+      table.wcpt-schedule td {
+        display: block; }
+      table.wcpt-schedule tr {
+        margin-bottom: 20px;
+        border: 1px solid #e5eced;
+        border-bottom: none; }
+      table.wcpt-schedule td {
+        border: none;
+        border-bottom: 1px solid #e5eced; }
+        table.wcpt-schedule td.wcpt-session-empty {
+          display: none; }
+      table.wcpt-schedule .wcpt-time {
+        padding: 20px;
+        font-family: "Nunito", "Tahoma", "Verdana", sans-serif;
+        font-size: 20px;
+        font-size: 2rem;
+        line-height: 1.3;
+        text-align: center;
+        border-bottom: 1px solid #e5eced;
+        background: rgba(126, 161, 184, 0.05);
+        width: 100%; }
+      table.wcpt-schedule .wcpt-session-type-session {
+        margin-bottom: 0; }
+        table.wcpt-schedule .wcpt-session-type-session::before {
+          font-size: 16px;
+          font-size: 1.6rem;
+          color: #303030;
+          border: none;
+          content: attr(data-track-title);
+          display: block;
+          margin: 0;
+          padding: 0; }
+          .global-session table.wcpt-schedule .wcpt-session-type-session::before {
+            display: none; }
+      table.wcpt-schedule .wcpt-session-title {
+        display: block;
+        margin: 15px 0;
+        padding: 0; }
+      table.wcpt-schedule .wcpt-session-speakers {
+        display: block;
+        padding: 0; }
+        table.wcpt-schedule .wcpt-session-speakers::before {
+          content: "Speaker: ";
+          font-style: normal; }
+        table.wcpt-schedule .wcpt-session-speakers a {
+          color: #21759b; } }
+
 /*--------------------------------------------------------------
 ## Comments
 --------------------------------------------------------------*/

--- a/style.css
+++ b/style.css
@@ -3025,7 +3025,8 @@ table.wcpt-schedule {
     border-top: 1px solid #e5eced;
     border-left: 1px solid #e5eced;
     font-size: 16px;
-    font-size: 1.6rem; }
+    font-size: 1.6rem;
+    vertical-align: top; }
   table.wcpt-schedule th {
     font-family: "Nunito", "Tahoma", "Verdana", sans-serif;
     font-size: 20px;
@@ -3033,11 +3034,13 @@ table.wcpt-schedule {
     line-height: 1.3;
     font-weight: 900;
     text-align: center;
-    background: rgba(126, 161, 184, 0.05); }
+    background: rgba(126, 161, 184, 0.05);
+    vertical-align: middle; }
   table.wcpt-schedule .wcpt-col-time,
   table.wcpt-schedule .wcpt-time {
     background: rgba(126, 161, 184, 0.05);
-    width: 6em; }
+    width: 6em;
+    text-align: left; }
   table.wcpt-schedule .wcpt-session-speakers {
     display: block;
     margin-top: 7.5px;
@@ -3047,6 +3050,8 @@ table.wcpt-schedule {
     border-top: none; }
   table.wcpt-schedule td[colspan]:not([colspan="1"]) {
     text-align: center; }
+  table.wcpt-schedule td[colspan="6"]:not(.wcb-session-opening-remarks) {
+    background: rgba(126, 161, 184, 0.05); }
   table.wcpt-schedule td div.wcb-session-favourite-icon a.fav-session-button {
     border: none;
     color: rgba(126, 161, 184, 0.5) !important; }


### PR DESCRIPTION
Style the schedule at wide sizes, and then copies the responsive CSS so we can make the breakpoint higher (currently 960px).

![Screen Shot 2019-08-12 at 6 41 04 PM](https://user-images.githubusercontent.com/541093/62903756-c8b71680-bd31-11e9-8102-1faf413cafbc.png)

Mid- and smaller screens:

![Screen Shot 2019-08-12 at 6 48 48 PM](https://user-images.githubusercontent.com/541093/62903770-d66c9c00-bd31-11e9-9d84-fdba45a8bceb.png)

@melchoyce I made up styles for the favoriting stars (the red is a favorited talk).

Right now it uses 960px as the breakpoint to switch to the single col display. Between 1280px and 960px, the table is the full width of the screen. I'm not sure if this works, or if we should use a higher breakpoint for the single column switch, or what. I figured it would be easier to decide what to do once the basic styles are merged.